### PR TITLE
Enhance API smoke tests for regeneration metadata

### DIFF
--- a/tests/test_api_light.py
+++ b/tests/test_api_light.py
@@ -13,7 +13,9 @@ def _generate_once() -> dict:
     data = response.json()
     for key in ("output_dir", "spec", "summary", "project", "sections", "track_stats"):
         assert key in data
+    # track_stats 应返回一个列表描述每条分轨的统计信息。
     assert isinstance(data["track_stats"], list)
+    # form 字段内含曲式段落描述，确保生成规格非空。
     assert data["project"]["form"]
     return data
 
@@ -44,4 +46,7 @@ def test_regenerate_section_structure() -> None:
     assert "project" in data
     assert "sections" in data
     assert len(data["track_stats"]) >= 1
-    assert "A" in data["sections"] or data["sections"]
+    # sections 字典应包含至少一个段落条目，这里抽取任意键并确认再生次数字段存在。
+    assert isinstance(data["sections"], dict) and data["sections"]
+    first_section = next(iter(data["sections"].values()))
+    assert "regeneration_count" in first_section


### PR DESCRIPTION
## Summary
- verify the generate smoke test asserts the response exposes track statistics and non-empty forms
- ensure the regenerate-section smoke test checks section metadata contains regeneration counters

## Testing
- pytest tests/test_persistence.py tests/test_api_light.py

------
https://chatgpt.com/codex/tasks/task_e_68dd638aea908328825b17b35c6fd56b