### PR TITLE
Add deployment tooling and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # 安装 shellcheck 以便检查部署脚本的 Bash 语法
+      - name: Install shellcheck
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -17,6 +23,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
+      # 使用 shellcheck 确认 Bash 脚本风格与潜在错误
+      - name: Lint shell scripts
+        run: shellcheck deploy/scripts/*.sh
       - name: Lint with black
         run: black --check src tests
       - name: Lint with isort
@@ -27,3 +36,13 @@ jobs:
         run: echo "flake8 检查由 black/isort 组合替代，避免重复规则冲突"
       - name: Run tests
         run: pytest -q
+      # 仅做静态检查：确认健康检查脚本存在且具备执行权限
+      - name: Verify health script executable
+        run: test -x deploy/scripts/check_health.sh
+      # 在 PR 打上 frontend 标签时，执行前端构建以确认产物可生成
+      - name: Frontend build dry run
+        if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'frontend') }}
+        run: |
+          cd web
+          npm ci
+          npm run build

--- a/README.md
+++ b/README.md
@@ -159,6 +159,15 @@ curl http://localhost:8000/config-public
 - **浏览器为什么没声音？** 浏览器需要用户手势激活音频，请先点击播放按钮或其他控件。
 - **跨域问题？** 确保后端启用了 CORS，并检查 `VITE_API_BASE` 是否指向正确域名与端口。
 
+## 10. 部署与运维
+- **最简部署命令清单**：
+  1. `bash deploy/scripts/install_python_venv.sh`
+  2. `cp deploy/env/.env.example.server .env && vim .env`
+  3. `bash deploy/scripts/setup_systemd.sh`
+  4. 配置 Nginx 或 Caddy（示例见 `deploy/nginx/` 与 `deploy/caddy/`）
+- **健康检查**：部署完成后务必执行 `bash deploy/scripts/check_health.sh` 与 `bash deploy/scripts/smoke_test.sh`，确保链路通畅。
+- **更多细节**：包含 Docker/Compose、日志、安全实践在内的完整指南请阅读 [`deploy/README_DEPLOY.md`](deploy/README_DEPLOY.md)。
+
 ## 10. 许可与致谢
 - 许可证：MIT（详见 [LICENSE](LICENSE)）。
 - 致谢：项目使用了 FastAPI、Typer、music21、pretty_midi、Tone.js、React、TailwindCSS、Shoelace 等开源库。

--- a/deploy/README_DEPLOY.md
+++ b/deploy/README_DEPLOY.md
@@ -1,0 +1,126 @@
+<!--
+  中文部署说明文档
+  本文件详细介绍项目在多种环境中的部署方式以及运维要点。
+-->
+# MotifMaker 部署与运维指南
+
+> 本文档帮助运维人员在保持核心功能不变的前提下，将 MotifMaker 后端（FastAPI）与前端（Vite+React）安全、稳定地部署到不同平台。
+
+## 1. 部署路径选择对比
+
+| 场景 | 优点 | 适用人群 | 备注 |
+| ---- | ---- | -------- | ---- |
+| VPS/裸机 | 完整控制系统、便于调优，使用 systemd + 反向代理 管理 | 熟悉 Linux 的研发/运维 | 需要自行维护安全补丁与监控 |
+| PaaS | 平台托管运行时，易于扩缩容 | 希望快速上线的团队 | 注意 PaaS 的资源配额与网络出站限制 |
+| Docker/Compose | 打包成容器，环境一致性强 | 想用容器化快速启动的人 | 适用于开发和小规模试运行 |
+| 反向代理（Nginx/Caddy） | 提供统一入口、TLS 与缓存 | 所有需要对外暴露服务的场景 | 建议后端仅监听回环地址 |
+
+> **提示：** 初次部署推荐按照 VPS 场景操作，随后可以根据团队经验迁移到 Docker 或 PaaS。
+
+## 2. VPS/裸机部署流程
+
+1. **克隆仓库**
+   ```bash
+   git clone https://your.git.repo/motifmaker.git
+   cd motifmaker
+   ```
+   - 在拉取前确认机器仅开放 22/80/443 端口。
+
+2. **创建虚拟环境并安装依赖**
+   ```bash
+   bash deploy/scripts/install_python_venv.sh
+   ```
+   - 脚本会创建 `.venv` 目录、安装 `requirements.txt`，遇到网络慢可按注释切换镜像源。
+
+3. **准备环境变量文件**
+   ```bash
+   cp deploy/env/.env.example.server .env
+   # 编辑 .env，填入 ALLOWED_ORIGINS、LOG_LEVEL 等参数
+   ```
+   - `.env` 含敏感信息，请勿提交到仓库。
+
+4. **注册 systemd 服务**
+   ```bash
+   bash deploy/scripts/setup_systemd.sh
+   ```
+   - 脚本会生成 `motifmaker.service`。完成后根据提示执行 `systemctl daemon-reload && systemctl enable --now motifmaker`。
+
+5. **配置反向代理**
+   - Nginx：将 `deploy/nginx/motifmaker.conf.example` 拷贝到 `/etc/nginx/conf.d/` 并按注释修改域名/路径。
+   - Caddy：将 `deploy/caddy/Caddyfile.example` 拷贝到 `/etc/caddy/`。
+   - 记得重新加载代理服务并检查 TLS。
+
+6. **健康检查与烟囱测试**
+   ```bash
+   bash deploy/scripts/check_health.sh
+   bash deploy/scripts/smoke_test.sh
+   ```
+   - 如有失败，根据脚本输出排查后端服务与反向代理。
+
+7. **防火墙与安全**
+   - 保持仅开放 22/80/443 端口。
+   - 后端 FastAPI 进程监听 `127.0.0.1`，只通过反向代理对外发布。
+
+## 3. Docker / Docker Compose 部署流程
+
+1. **准备环境变量**
+   ```bash
+   cp deploy/env/.env.example.docker .env
+   ```
+   - Compose 会读取 `.env` 中的同名变量注入容器。
+
+2. **构建并启动容器**
+   ```bash
+   docker compose -f deploy/docker/docker-compose.yml up -d
+   ```
+   - `api` 服务暴露 `8000`，`web` 服务暴露 `80`。首次启动会自动安装依赖并编译前端。
+
+3. **卷与数据持久化**
+   - `outputs/` 与 `projects/` 使用卷挂载到宿主，确保生成的 MIDI/JSON 不丢失。
+   - 如需远程存储，可替换为对象存储或 NFS。
+
+4. **访问服务**
+   - 浏览器访问 `http://<宿主机 IP>`，前端会通过 `VITE_API_BASE` 指向后端。
+
+5. **停止与更新**
+   ```bash
+   docker compose -f deploy/docker/docker-compose.yml down
+   docker compose -f deploy/docker/docker-compose.yml pull
+   docker compose -f deploy/docker/docker-compose.yml up -d
+   ```
+   - 更新镜像后重新启动即可。
+
+## 4. 域名与 HTTPS 配置
+
+- **Nginx + Certbot**
+  1. 安装 Certbot：`sudo apt install certbot python3-certbot-nginx`。
+  2. 执行 `sudo certbot --nginx -d api.example.com`，根据向导完成证书申请。
+  3. 定期检查 `systemctl status certbot.timer` 确认证书续期正常。
+
+- **Caddy 自动证书**
+  - Caddy 会自动向 Let’s Encrypt 申请证书，只需确保 80/443 端口开放。
+  - 首次申请可能因 DNS 解析未生效而失败，可稍后重试。
+
+## 5. 日志与监控建议
+
+- 使用 `deploy/scripts/tail_logs.sh` 快速查看后端 journal 日志，Nginx/Caddy 日志请分别查看 `/var/log/nginx/` 或 `/var/lib/caddy/`。
+- 应用日志遵循 `src/motifmaker/logging_setup.py` 中的结构，未来可对接 Loki 或 ELK。
+- 建议使用 node_exporter + Prometheus 采集系统指标，或在容器环境中启用 cAdvisor。
+
+## 6. 安全实践
+
+- `.env` 不应纳入版本控制，敏感参数可交由秘密管理服务（如 Vault、AWS Secrets Manager）。
+- `ALLOWED_ORIGINS` 仅填入可信前端域名，防止跨站请求。
+- 及时更新依赖与基础镜像，执行 `pip list --outdated` 与 `npm outdated` 了解升级需求。
+
+## 7. 目录忽略与产物管理
+
+- 仓库已在 `.gitignore` 中忽略 `outputs/`、`projects/`、`web/dist/`、`*.mid` 等二进制产物。
+- 部署脚本只生成必要配置，不会写入二进制文件。
+
+## 8. 进一步的可运维化计划
+
+- 后续可引入 Kubernetes，相关约束可参考 `deploy/k8s/README_k8s.md` 占位说明。
+- 建议在 CI/CD 中接入 smoke test 并推送到监控平台。
+
+> 若遇到部署问题，请记录命令输出与日志，便于快速定位。

--- a/deploy/caddy/Caddyfile.example
+++ b/deploy/caddy/Caddyfile.example
@@ -1,0 +1,12 @@
+# ==========================================
+# MotifMaker Caddy 示例配置
+# 说明：Caddy 将自动为域名申请 Let’s Encrypt 证书，以下站点为占位符。
+# 本配置通过 reverse_proxy 将流量转发到本地 Uvicorn。
+# ==========================================
+
+api.example.com {
+    reverse_proxy 127.0.0.1:8000
+    # 可使用以下命令在本地测试 Caddy：
+    #   caddy run --config deploy/caddy/Caddyfile.example --adapter caddyfile
+    # 若在开发机运行，请将域名修改为 localhost 并设置 hosts 文件。
+}

--- a/deploy/docker/Dockerfile.api
+++ b/deploy/docker/Dockerfile.api
@@ -1,0 +1,39 @@
+# ==========================================
+# MotifMaker 后端镜像构建文件
+# 基础镜像：python:3.10-slim，适合生产环境使用的轻量版本。
+# 注意：镜像仅包含运行后端所需依赖，不打包任何生成的二进制产物。
+# ==========================================
+
+FROM python:3.10-slim AS runtime
+
+# 设置工作目录并安装基础依赖。仅保留最小构建环境，避免镜像膨胀。
+WORKDIR /app
+
+# 安装系统级依赖（按需调整）。build-essential 可用于编译部分 Python 包，部署后可删除以缩减镜像。
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# 复制依赖文件并安装，优先利用缓存。
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# 复制源代码。
+COPY src/ ./src/
+
+# 设置环境变量，值从运行时传入。
+ENV API_TITLE="MotifMaker API" \
+    API_VERSION="0.2.0" \
+    ALLOWED_ORIGINS="http://localhost" \
+    OUTPUT_DIR="/app/outputs" \
+    PROJECTS_DIR="/app/projects" \
+    RATE_LIMIT_RPS="2" \
+    LOG_LEVEL="INFO" \
+    HOST="0.0.0.0" \
+    PORT="8000"
+
+# 创建持久化目录（部署时可通过卷覆盖）。
+RUN mkdir -p /app/outputs /app/projects
+
+# 启动命令：直接使用 Uvicorn 运行 FastAPI 应用。
+CMD ["uvicorn", "motifmaker.api:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]

--- a/deploy/docker/Dockerfile.web
+++ b/deploy/docker/Dockerfile.web
@@ -1,0 +1,31 @@
+# ==========================================
+# MotifMaker 前端镜像构建文件
+# 使用多阶段构建：阶段一使用 node:18-alpine 构建静态资源，阶段二使用 nginx:alpine 提供静态服务。
+# 注意：仓库不提交 web/dist 产物，镜像应由 CI/CD 构建并推送。
+# ==========================================
+
+FROM node:18-alpine AS builder
+WORKDIR /app
+
+# 复制 package.json 和锁定文件，保持依赖一致。
+COPY web/package.json web/package-lock.json ./
+RUN npm ci
+
+# 复制前端源代码并构建。
+COPY web/ ./
+RUN npm run build
+
+# 运行阶段：使用 Nginx 提供静态资源。
+FROM nginx:alpine AS runtime
+
+# 拷贝自定义 Nginx 配置（如需），此处使用默认即可。
+# COPY deploy/docker/nginx.conf /etc/nginx/conf.d/default.conf
+
+# 将构建出的静态文件放入默认站点目录。
+COPY --from=builder /app/dist/ /usr/share/nginx/html/
+
+# 暴露端口 80，容器启动后可直接访问静态页面。
+EXPOSE 80
+
+# 使用默认的 nginx 启动命令。
+CMD ["nginx", "-g", "daemon off;"]

--- a/deploy/docker/docker-compose.yml
+++ b/deploy/docker/docker-compose.yml
@@ -1,0 +1,37 @@
+# ==========================================
+# MotifMaker Docker Compose 示例
+# 用途：快速在单机上启动后端 API 与前端静态站点。
+# 注意：生产环境建议使用专业编排（Kubernetes/Swarm）并配置独立负载均衡与对象存储。
+# ==========================================
+
+version: '3.9'
+
+services:
+  api:
+    build:
+      context: ../..
+      dockerfile: deploy/docker/Dockerfile.api
+    container_name: motifmaker-api
+    env_file:
+      - ../../.env  # 从仓库根目录读取，与 deploy/env/.env.example.docker 一致
+    ports:
+      - "8000:8000"
+    volumes:
+      - ../../outputs:/app/outputs
+      - ../../projects:/app/projects
+    restart: unless-stopped
+    # 提示：如需在生产中启用多副本，请结合外部负载均衡与共享存储。
+
+  web:
+    build:
+      context: ../..
+      dockerfile: deploy/docker/Dockerfile.web
+    container_name: motifmaker-web
+    depends_on:
+      - api
+    environment:
+      - VITE_API_BASE=http://localhost:8000  # 前端默认指向 api 服务，可通过 .env 覆盖
+    ports:
+      - "80:80"
+    restart: unless-stopped
+    # 提示：生产中静态资源可托管在 CDN，Compose 方案适合开发或内部演示。

--- a/deploy/env/.env.example.docker
+++ b/deploy/env/.env.example.docker
@@ -1,0 +1,17 @@
+# ===============================
+# MotifMaker 容器化环境变量示例
+# 用途：使用 docker compose 部署时复制到仓库根目录 .env，供 Compose 自动加载。
+# 说明：变量名与服务器场景保持一致，方便在不同部署方案间切换。
+# ===============================
+
+API_TITLE=MotifMaker API
+API_VERSION=0.2.0
+ALLOWED_ORIGINS=http://localhost,http://localhost:5173
+OUTPUT_DIR=/app/outputs
+PROJECTS_DIR=/app/projects
+RATE_LIMIT_RPS=2
+LOG_LEVEL=INFO
+HOST=0.0.0.0
+PORT=8000
+
+# docker-compose.yml 会将上述变量注入容器环境，详情请参考 deploy/README_DEPLOY.md。

--- a/deploy/env/.env.example.server
+++ b/deploy/env/.env.example.server
@@ -1,6 +1,7 @@
 # ===============================
-# MotifMaker 环境变量示例（开发/部署通用）
-# 使用说明：复制为项目根目录的 .env 后按需调整，并参考 deploy/README_DEPLOY.md 获取完整部署步骤。
+# MotifMaker 服务器环境变量示例
+# 用途：裸机或 VPS 部署时复制到项目根目录的 .env 使用。
+# 说明：所有键均需根据实际环境调整，请勿将真实凭据提交到版本库。
 # ===============================
 
 # API_TITLE 控制 FastAPI 文档标题，生产环境可填入公司/品牌名称。
@@ -24,8 +25,10 @@ RATE_LIMIT_RPS=2
 # LOG_LEVEL 控制日志详细程度，可选 DEBUG/INFO/WARNING/ERROR。
 LOG_LEVEL=INFO
 
-# HOST 为 Uvicorn 监听地址，开发可用 127.0.0.1，生产建议回环并由反向代理暴露。
+# HOST 为 Uvicorn 监听地址，生产建议保持 127.0.0.1 仅供反向代理访问。
 HOST=127.0.0.1
 
 # PORT 为 Uvicorn 监听端口，默认 8000，需与反向代理 upstream 配置保持一致。
 PORT=8000
+
+# 参考部署步骤请阅读 deploy/README_DEPLOY.md。

--- a/deploy/k8s/README_k8s.md
+++ b/deploy/k8s/README_k8s.md
@@ -1,0 +1,12 @@
+<!--
+  MotifMaker Kubernetes 占位说明
+  当前版本未提供完整清单，后续可根据部署需求扩展。
+-->
+# MotifMaker Kubernetes 部署提示
+
+- 本目录预留给未来的 Kubernetes 配置（Deployment、Service、Ingress 等）。
+- 如需自行编写清单，请参考以下建议：
+  - 使用 ConfigMap 或 Secret 注入环境变量，确保敏感信息安全。
+  - 通过 PersistentVolume 声明 outputs/ 与 projects/ 持久化卷。
+  - 使用 HorizontalPodAutoscaler 根据 CPU/MEM 或自定义指标扩缩容。
+- 完整步骤可在后续版本补充，欢迎在 issue 中反馈需求。

--- a/deploy/nginx/motifmaker.conf.example
+++ b/deploy/nginx/motifmaker.conf.example
@@ -1,0 +1,29 @@
+# ==========================================
+# MotifMaker Nginx 示例配置
+# 说明：将此文件放置到 /etc/nginx/conf.d/ 并根据实际域名、路径调整。
+# 注意：以下配置监听 80 端口，可配合 Certbot 申请 HTTPS 证书。
+# ==========================================
+
+server {
+    listen 80;
+    server_name api.example.com;  # 替换为真实域名或使用 _ 作为通配
+
+    # 如果需要 TLS，可在证书申请完成后增加 listen 443 ssl http2; 并配置证书路径。
+    # 推荐执行：sudo certbot --nginx -d api.example.com
+
+    client_max_body_size 8m;  # 限制上传文件大小，避免过载
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;  # 后端 Uvicorn 监听地址
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 300s;
+    }
+
+    # 可选：将静态文件交由前端静态站点或 CDN 提供。
+}

--- a/deploy/scripts/check_health.sh
+++ b/deploy/scripts/check_health.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# ===============================
+# MotifMaker 部署脚本：check_health.sh
+# 功能：调用后端健康检查与版本接口，验证基础服务状态。
+# 使用提示：部署后在反向代理或本机执行，失败时会返回非零退出码。
+# ===============================
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://127.0.0.1:8000}"
+
+printf '[信息] 检查后端健康状态：%s\n' "${BASE_URL}"
+
+if HEALTH_RESPONSE=$(curl -sf "${BASE_URL}/healthz"); then
+  printf '[成功] /healthz 返回：%s\n' "${HEALTH_RESPONSE}"
+else
+  echo "[错误] /healthz 检查失败，请确认服务已启动。" >&2
+  exit 1
+fi
+
+if VERSION_RESPONSE=$(curl -sf "${BASE_URL}/version"); then
+  printf '[成功] /version 返回：%s\n' "${VERSION_RESPONSE}"
+else
+  echo "[错误] /version 检查失败，可能是应用未加载或路由变更。" >&2
+  exit 1
+fi

--- a/deploy/scripts/install_python_venv.sh
+++ b/deploy/scripts/install_python_venv.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# ===============================
+# MotifMaker 部署脚本：install_python_venv.sh
+# 功能：在当前仓库目录内创建 Python 虚拟环境，安装依赖并输出常见排障建议。
+# 使用场景：VPS/裸机部署首次执行；重复运行会复用已有虚拟环境。
+# 风险提示：脚本使用 set -euo pipefail，遇到错误会立即退出以避免部分操作成功造成脏环境。
+# ===============================
+set -euo pipefail
+
+# 目录与文件定义，可根据需要修改但需同步 systemd 配置。
+VENV_DIR=".venv"
+REQUIREMENTS_FILE="requirements.txt"
+
+cat <<'DESC'
+[信息] 开始初始化 Python 虚拟环境。
+- 若需要使用镜像源，请在执行前设置 PIP_INDEX_URL 或在下方命令中追加 -i 参数。
+- 如果网络环境受限，可参考 deploy/README_DEPLOY.md 中的“常见问题”使用离线包。
+DESC
+
+# 检查 Python 是否可用，并提示版本。
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "[错误] 未找到 python3，请先安装 Python 3.10+。" >&2
+  exit 1
+fi
+python3 --version
+
+# 创建虚拟环境；若已存在则跳过创建。
+if [ ! -d "${VENV_DIR}" ]; then
+  echo "[信息] 创建虚拟环境目录 ${VENV_DIR}"
+  python3 -m venv "${VENV_DIR}"
+else
+  echo "[信息] 检测到已有虚拟环境，直接复用 ${VENV_DIR}"
+fi
+
+# 激活虚拟环境并升级 pip。
+# shellcheck disable=SC1091 # 允许 source 虚拟环境激活脚本。
+source "${VENV_DIR}/bin/activate"
+
+python -m pip install --upgrade pip
+
+# 安装项目依赖，可根据需求切换为 requirements-dev.txt。
+if [ -f "${REQUIREMENTS_FILE}" ]; then
+  echo "[信息] 使用 ${REQUIREMENTS_FILE} 安装依赖"
+  pip install -r "${REQUIREMENTS_FILE}"
+else
+  echo "[警告] 未找到 ${REQUIREMENTS_FILE}，请检查文件路径。" >&2
+  exit 1
+fi
+
+cat <<'DESC'
+[完成] 虚拟环境准备就绪。
+- 如需启用 pre-commit，可以执行 "pip install pre-commit && pre-commit install"。
+- 若安装速度缓慢，考虑使用如 https://mirrors.aliyun.com/pypi/simple 的镜像源。
+DESC

--- a/deploy/scripts/reload_systemd.sh
+++ b/deploy/scripts/reload_systemd.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# ===============================
+# MotifMaker 部署脚本：reload_systemd.sh
+# 功能：快捷执行 daemon-reload 并重启 motifmaker 服务，适用于更新代码或配置后。
+# 提示：脚本默认调用用户级 systemd，可根据需要添加 sudo 切换至系统级。
+# ===============================
+set -euo pipefail
+
+SYSTEMCTL_CMD="systemctl --user"
+
+cat <<'DESC'
+[信息] 开始重新加载 systemd 并重启 motifmaker。
+如需在系统级服务上操作，请将命令替换为 "sudo systemctl"。
+DESC
+
+${SYSTEMCTL_CMD} daemon-reload
+${SYSTEMCTL_CMD} restart motifmaker
+
+${SYSTEMCTL_CMD} status motifmaker --no-pager

--- a/deploy/scripts/run_uvicorn_dev.sh
+++ b/deploy/scripts/run_uvicorn_dev.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# ===============================
+# MotifMaker 部署脚本：run_uvicorn_dev.sh
+# 功能：在本地虚拟环境中启动 Uvicorn 单进程，便于开发或临时验证。
+# 风险提示：仅适用于开发环境；生产部署应使用 systemd + 反向代理确保高可用与安全。
+# ===============================
+set -euo pipefail
+
+# shellcheck disable=SC1091 # 允许 source 虚拟环境激活脚本。
+if [ -d ".venv" ]; then
+  source .venv/bin/activate
+else
+  echo "[错误] 未检测到 .venv 虚拟环境，请先执行 deploy/scripts/install_python_venv.sh" >&2
+  exit 1
+fi
+
+HOST_VALUE="${HOST:-127.0.0.1}"
+PORT_VALUE="${PORT:-8000}"
+
+echo "[信息] 启动 Uvicorn，监听 ${HOST_VALUE}:${PORT_VALUE}，仅用于开发调试。"
+exec uvicorn motifmaker.api:app --host "${HOST_VALUE}" --port "${PORT_VALUE}" --workers 1

--- a/deploy/scripts/setup_systemd.sh
+++ b/deploy/scripts/setup_systemd.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# ===============================
+# MotifMaker 部署脚本：setup_systemd.sh
+# 功能：生成 systemd 单元文件，指向当前仓库中的 Uvicorn 启动命令。
+# 默认写入用户级服务目录 ~/.config/systemd/user/，如需系统级服务请按注释调整。
+# 安全提示：脚本不会自动执行 systemctl 命令，需人工确认后再启用服务。
+# ===============================
+set -euo pipefail
+
+REPO_DIR="$(pwd)"
+SERVICE_NAME="motifmaker.service"
+USER_SYSTEMD_DIR="${HOME}/.config/systemd/user"
+VENV_PATH="${REPO_DIR}/.venv/bin/uvicorn"
+ENV_FILE="${REPO_DIR}/.env"
+HOST_VALUE="${HOST:-127.0.0.1}"
+PORT_VALUE="${PORT:-8000}"
+
+cat <<DESC
+[信息] 准备生成 systemd 服务：${SERVICE_NAME}
+- 仓库路径：${REPO_DIR}
+- 虚拟环境 Uvicorn：${VENV_PATH}
+- 环境变量文件：${ENV_FILE}
+- 监听地址：${HOST_VALUE}:${PORT_VALUE}
+DESC
+
+mkdir -p "${USER_SYSTEMD_DIR}"
+SERVICE_PATH="${USER_SYSTEMD_DIR}/${SERVICE_NAME}"
+
+cat <<SERVICE > "${SERVICE_PATH}"
+# MotifMaker systemd 单元文件
+# 说明：此文件由 deploy/scripts/setup_systemd.sh 自动生成，用于用户级 systemd。
+# 若需要写入 /etc/systemd/system/，请复制后由具有 sudo 权限的用户部署。
+[Unit]
+Description=MotifMaker FastAPI Service
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=${REPO_DIR}
+EnvironmentFile=${ENV_FILE}
+ExecStart=${VENV_PATH} motifmaker.api:app --host ${HOST_VALUE} --port ${PORT_VALUE} --workers 2
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+SERVICE
+
+cat <<'DESC'
+[完成] systemd 单元文件已写入。
+接下来请手动执行以下命令完成启用：
+  systemctl --user daemon-reload
+  systemctl --user enable --now motifmaker
+
+如需部署到系统级服务，可在 sudo 环境下将文件复制至 /etc/systemd/system/ 并运行：
+  sudo systemctl daemon-reload
+  sudo systemctl enable --now motifmaker
+
+查看运行状态：
+  systemctl --user status motifmaker
+查看日志：
+  journalctl --user -u motifmaker -f
+DESC

--- a/deploy/scripts/smoke_test.sh
+++ b/deploy/scripts/smoke_test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# ===============================
+# MotifMaker 部署脚本：smoke_test.sh
+# 功能：向 /generate 接口发送轻量提示词，验证核心链路（请求 -> 推理调度 -> 响应）。
+# 注意：脚本仅检查响应字段，不会下载或保存产物，适合部署后的烟囱测试。
+# ===============================
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://127.0.0.1:8000}"
+PROMPT="城市夜景 温暖而克制 约两分钟"
+
+printf '[信息] 对 %s 发送烟囱测试请求。\n' "${BASE_URL}"
+
+RESPONSE=$(curl -sf -X POST "${BASE_URL}/generate" \
+  -H 'Content-Type: application/json' \
+  -d "{\"prompt\": \"${PROMPT}\"}") || {
+  echo "[错误] 请求 /generate 失败，请检查后端日志。" >&2
+  exit 1
+}
+
+printf '[信息] 返回 JSON：%s\n' "${RESPONSE}"
+
+if echo "${RESPONSE}" | grep -q '"ok"\s*:\s*true' && \
+   echo "${RESPONSE}" | grep -q '"mid_path"' && \
+   echo "${RESPONSE}" | grep -q '"json_path"'; then
+  echo "[成功] 检测到 ok=true 且包含 mid_path/json_path 字段，烟囱测试通过。"
+else
+  echo "[错误] 响应缺少关键字段，请检查后端业务逻辑。" >&2
+  exit 1
+fi

--- a/deploy/scripts/tail_logs.sh
+++ b/deploy/scripts/tail_logs.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# ===============================
+# MotifMaker 部署脚本：tail_logs.sh
+# 功能：实时查看 systemd 中 motifmaker 服务日志，辅助排障。
+# 使用提示：默认监听用户级 journal，如需系统级请在命令前加 sudo 并移除 --user。
+# ===============================
+set -euo pipefail
+
+SYSTEMCTL_SCOPE="--user"
+UNIT_NAME="motifmaker"
+
+cat <<'DESC'
+[信息] 正在持续输出 motifmaker 日志。
+- 退出可使用 Ctrl+C。
+- 过滤关键字示例：journalctl --user -u motifmaker | grep "ERROR"。
+DESC
+
+journalctl ${SYSTEMCTL_SCOPE} -u "${UNIT_NAME}" -f


### PR DESCRIPTION
## Summary
- add deployment documentation, environment templates, and reverse proxy samples under deploy/
- provide bash scripts for venv setup, systemd management, health checks, smoke tests, and log tailing
- ship docker compose assets and extend CI to lint shell scripts and verify health check executability while updating README guidance

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e606d30b2c832884a6bf35dfbeca6f