### PR TITLE
feat: enforce english-only web ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Motifmaker
 
+## 🌍 Language
+Current UI language: **English Only**
+(All labels, tooltips, and prompts have been unified in English for consistency and better global readability.)
+
 ## 1. 项目简介
 Motifmaker 是一个分层式音乐生成原型，支持从自然语言 Prompt → 骨架 JSON → 动机 → 段落展开 → 和声 → 渲染 → MIDI → Web UI 试听与下载的全流程。系统强调模块解耦，既适合研究实验，也能拓展成音乐创作工具。
 
@@ -56,12 +60,13 @@ Prompt → 解析层(parsing) → 骨架JSON(schema) → 动机生成(motif)
 3. 浏览器访问 [http://localhost:5173](http://localhost:5173)。如需指向远程后端，可在启动前设置 `VITE_API_BASE=http://后端地址:端口`。
 
 ### 前端 UI 使用说明
+- The interface language has been standardized to English. The i18n infrastructure remains intact for future translation.
 - 见 Piano-Roll 可视化与参数面板。
-- 顶部状态条可切换中英文语言、深浅主题，并查看后端健康状态与接口地址。
+- 顶部状态条提供固定的 “English Only” 提示与主题切换按钮，可查看后端健康状态与接口地址。
 - Prompt 面板支持 Alt+Enter 快速触发生成，参数覆盖区可随时重置为后端最新解析结果。
 - 曲式表格支持键盘导航：方向键移动单元格、Enter 编辑、Esc 取消，新增的冻结列可批量勾选后点击“冻结选中的动机”。
 - 播放器与 Piano-Roll 联动：拖动进度条或点击 Piano-Roll 任意位置都会同步播放指针，循环模式可在播放器右侧开关。
-- “复制骨架 JSON” 与 “导出当前视图设置” 会分别写入剪贴板与 localStorage，导出内容包含 Piano-Roll 缩放、主题与语言偏好。
+- “复制骨架 JSON” 与 “导出当前视图设置” 会分别写入剪贴板与 localStorage，导出内容包含 Piano-Roll 缩放与主题偏好（语言固定为英文）。
 - 常见错误提示：
   - 若播放器无声，多半是浏览器自动静音限制；请先点击播放键并确认系统音量。
   - 若请求失败，Shoelace `<sl-alert>` 会在顶部出现错误提示，常见原因包括跨域配置或后端服务未启动。

--- a/deploy/README_DEPLOY.md
+++ b/deploy/README_DEPLOY.md
@@ -6,6 +6,8 @@
 
 > 本文档帮助运维人员在保持核心功能不变的前提下，将 MotifMaker 后端（FastAPI）与前端（Vite+React）安全、稳定地部署到不同平台。
 
+> As of this release, the MotifMaker web interface is in English only. To localize in the future, extend the i18n dictionary before rebuilding the web bundle.
+
 ## 1. 部署路径选择对比
 
 | 场景 | 优点 | 适用人群 | 备注 |

--- a/web/scripts/check_i18n_consistency.ts
+++ b/web/scripts/check_i18n_consistency.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+// 脚本目标：扫描组件目录，检测是否仍存在中文字符，保障当前版本 UI 保持英文统一，可在未来 PR 流程中作为自动校验步骤。
+const componentsDir = path.join(__dirname, "..", "src", "components");
+const chineseRegex = /[\u4e00-\u9fa5]/;
+let hasWarning = false;
+let inBlockComment = false;
+
+// 若未来组件目录结构调整，可在此扩展为递归遍历，便于在 CI 中复用。
+const componentFiles = fs
+  .readdirSync(componentsDir)
+  .filter((file) => file.endsWith(".tsx"));
+
+for (const file of componentFiles) {
+  const fullPath = path.join(componentsDir, file);
+  const content = fs.readFileSync(fullPath, "utf8");
+  const lines = content.split(/\r?\n/);
+  lines.forEach((line, index) => {
+    const trimmed = line.trim();
+
+    if (inBlockComment) {
+      if (trimmed.includes("*/")) {
+        inBlockComment = false;
+      }
+      return;
+    }
+
+    if (trimmed.startsWith("/*")) {
+      if (!trimmed.includes("*/")) {
+        inBlockComment = true;
+      }
+      return;
+    }
+
+    const codeWithoutInlineComment = line.split("//")[0];
+    let sanitized = codeWithoutInlineComment.replace(/\/\*.*?\*\//g, "");
+    if (!sanitized.trim() || /^[{}]*$/.test(sanitized.trim())) {
+      return;
+    }
+
+    if (chineseRegex.test(sanitized)) {
+      if (!hasWarning) {
+        console.warn("Chinese characters detected in UI source files:");
+        hasWarning = true;
+      }
+      console.warn(` - ${file}:${index + 1}`);
+    }
+  });
+}
+
+if (!hasWarning) {
+  console.log("No Chinese characters found in src/components/*.tsx. UI language is consistent.");
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -43,7 +43,9 @@ interface LogEntry {
 const VIEW_STORAGE_KEY = "motifmaker.viewSettings";
 const THEME_STORAGE_KEY = "motifmaker.theme";
 
-const DEFAULT_PROMPT = "城市夜景、温暖而克制、B 段最高张力、现代古典+电子、约2分钟";
+// 统一默认 Prompt 为英文示例，避免初次加载时出现中文提示文案。
+const DEFAULT_PROMPT =
+  "Gentle night cityscape, warm but restrained, B section peak tension, modern classical + electronic, about 2 minutes";
 
 /**
  * App 组件：整合前端所有功能模块，管理请求状态与布局。
@@ -52,7 +54,7 @@ const DEFAULT_PROMPT = "城市夜景、温暖而克制、B 段最高张力、现
  * - 通过 AbortController 及请求状态避免竞态，保障 UI 可预期。
  */
 const App: React.FC = () => {
-  const { t, lang } = useI18n();
+  const { t } = useI18n();
   const [promptText, setPromptText] = useState(DEFAULT_PROMPT);
   const [baseSpec, setBaseSpec] = useState<ProjectSpec | null>(null); // 后端权威 ProjectSpec，表格编辑直接更新该状态。
   const [lastRender, setLastRender] = useState<RenderSuccess | null>(null); // 最近一次渲染结果，驱动下载与播放器。
@@ -428,21 +430,20 @@ const App: React.FC = () => {
   );
 
   const handleExportView = useCallback(async () => {
-    // 导出视图设置：写入 Piano-Roll 缩放、主题与语言到 localStorage，便于再次加载。
+    // 导出视图设置：仅写入 Piano-Roll 缩放与主题偏好；语言固定为英文无需持久化。
     if (typeof window === "undefined") return;
     setExportingView(true);
     try {
       const payload = {
         pianoScale,
         theme,
-        lang,
       };
       window.localStorage.setItem(VIEW_STORAGE_KEY, JSON.stringify(payload));
       appendLog("log.viewSaved", "success");
     } finally {
       setExportingView(false);
     }
-  }, [appendLog, lang, pianoScale, theme]);
+  }, [appendLog, pianoScale, theme]);
 
   const handlePlayerProgress = useCallback((time: number) => {
     setPlaybackTime(time);

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -189,7 +189,8 @@ async function postJson<T>(
   try {
     data = await response.json();
   } catch (error) {
-    throw new ApiError("响应解析失败，请检查网络或后端日志", response.status);
+    // API 返回体解析失败时统一输出英文提示，避免前端弹窗出现中文残留。
+    throw new ApiError("Failed to parse response body. Please check the network or backend logs.", response.status);
   }
 
   const parsed = data as
@@ -201,7 +202,7 @@ async function postJson<T>(
       ? parsed.error
       : { message: `HTTP ${response.status}`, code: undefined };
     throw new ApiError(
-      errorPayload.message ?? "未知错误",
+      errorPayload.message ?? "Unknown error",
       response.status,
       errorPayload.code,
       errorPayload.details

--- a/web/src/components/PromptPanel.tsx
+++ b/web/src/components/PromptPanel.tsx
@@ -13,10 +13,11 @@ export interface PromptPanelProps {
   loading: boolean; // 是否处于加载状态，用于禁用按钮与展示提示。
 }
 
+// 预设模板统一改为英文描述，覆盖多种风格便于国际用户参考与快速上手。
 const PROMPT_TEMPLATES: string[] = [
-  "城市夜景、温暖而克制、B 段最高张力、现代古典+电子、约2分钟",
-  "赛博朋克追逐场景、快速节奏、带有不规则鼓组与金属合成器",
-  "日落海边、柔和摇摆、Lo-Fi 质感、加入爵士和声色彩",
+  "Dreamy lo-fi beat for a rainy evening, piano and vinyl textures, around 90 BPM",
+  "High-energy cyberpunk chase with irregular drums and metallic synths, 140 BPM",
+  "Sunset beach swing with gentle jazz harmony, relaxed groove near 110 BPM",
 ];
 
 const PromptPanel: React.FC<PromptPanelProps> = ({

--- a/web/src/components/TopStatusBar.tsx
+++ b/web/src/components/TopStatusBar.tsx
@@ -10,14 +10,14 @@ export interface TopStatusBarProps {
 }
 
 /**
- * TopStatusBar 组件：展示后端健康状态、版本信息、接口地址以及语言/主题切换。
+ * TopStatusBar 组件：展示后端健康状态、版本信息、接口地址以及主题切换。
  * 设计重点：
  * 1. useEffect 内部执行 30 秒轮询，并在返回函数中清理定时器与 AbortController，避免内存泄漏；
  * 2. 利用 useRef 记录组件是否已卸载，防止异步请求返回后再 setState；
- * 3. 通过 useI18n 提供的 setLang 和 t() 完成国际化切换，并将语言写入 localStorage。
+ * 3. 语言切换暂时下线，仅展示固定“English Only”提示；未来可恢复多语言时再启用下拉框。
  */
 const TopStatusBar: React.FC<TopStatusBarProps> = ({ busy, lastError, theme, onThemeChange }) => {
-  const { lang, setLang, t } = useI18n();
+  const { t } = useI18n();
   const [health, setHealth] = useState<HealthResponse | null>(null);
   const [versionInfo, setVersionInfo] = useState<string | null>(null);
   const [publicConfig, setPublicConfig] = useState<ConfigPublicResponse | null>(null);
@@ -146,20 +146,11 @@ const TopStatusBar: React.FC<TopStatusBarProps> = ({ busy, lastError, theme, onT
           >
             {t("status.refresh")}
           </button>
-          <label className="flex items-center gap-2">
+          <div className="flex items-center gap-2">
             <span className="text-slate-500 dark:text-slate-400">{t("status.language")}</span>
-            <sl-select
-              value={lang}
-              className="w-28"
-              onSlChange={(event: CustomEvent) => {
-                const target = event.target as HTMLSelectElement;
-                setLang(target.value as "zh" | "en");
-              }}
-            >
-              <sl-option value="zh">中文</sl-option>
-              <sl-option value="en">English</sl-option>
-            </sl-select>
-          </label>
+            {/* 当前版本固定为英文模式，未来如需多语言支持，可重新启用语言切换开关。*/}
+            <span className="text-sm opacity-70">{t("status.englishOnly")}</span>
+          </div>
           <label className="flex items-center gap-2">
             <span className="text-slate-500 dark:text-slate-400">{t("status.theme")}</span>
             <sl-switch

--- a/web/src/hooks/useI18n.ts
+++ b/web/src/hooks/useI18n.ts
@@ -8,7 +8,8 @@ import I18nContext, { TranslationKey, Lang } from "../i18n";
 export function useI18n() {
   const context = useContext(I18nContext);
   if (!context) {
-    throw new Error("useI18n 必须在 <I18nProvider> 内使用");
+    // 为保持错误信息英文化，仅在注释中说明原因，避免 UI 出现中文残留。
+    throw new Error("useI18n must be used within <I18nProvider>.");
   }
   return context;
 }

--- a/web/src/i18n.tsx
+++ b/web/src/i18n.tsx
@@ -1,154 +1,20 @@
 import React, { createContext, useCallback, useEffect, useMemo, useState } from "react";
 
-/**
- * 轻量级的多语言上下文：本轮仅需中英文切换，因此不引入成熟 i18n 库，
- * 通过手写字典与 Hook 组合满足基础需求。后续若要扩展更多语言，可替换为
- * i18next 等方案，同时保留本文件中对 localStorage、占位插值的约定。
- */
-export type Lang = "zh" | "en";
+// ✅ 当前版本仅保留英文语言，方便国际化扩展：保留 i18n 架构，未来可通过新增 zh/en/jp/fr 等词典 JSON 恢复多语言切换。
+export type Lang = "en";
 
 /**
- * 词条键值映射：所有 UI 文案统一从此处读取。
- * - key 采用 "模块.含义" 的形式，便于检索；
- * - value 支持 {{placeholder}} 占位符，用于动态插值。
+ * 词条键值映射：所有 UI 文案统一从此处读取，保持英文 UI 一致性。
+ * - key 仍沿用模块化命名，便于后续扩展更多语言；
+ * - value 完全使用英文，避免界面出现中文残留。
  */
 export const dictionary = {
-  zh: {
-    "status.running": "运行中",
-    "status.idle": "空闲",
-    "status.backendHealthy": "后端正常",
-    "status.backendIssue": "后端异常",
-    "status.lastChecked": "上次检查",
-    "status.version": "后端版本",
-    "status.environment": "接口地址",
-    "status.language": "语言",
-    "status.theme": "主题",
-    "status.themeLight": "浅色",
-    "status.themeDark": "深色",
-    "status.refresh": "刷新健康状态",
-    "status.healthChecking": "正在检查...",
-    "status.healthError": "无法连接后端",
-
-    "prompt.title": "自然语言 Prompt",
-    "prompt.subtitle": "描述情绪/配器/时长/段落重点，支持键盘 Tab 导航",
-    "prompt.templates": "快速套用模板",
-    "prompt.placeholder": "例：城市夜景的 Lo-Fi 节奏，配器包含钢琴与弦乐",
-    "prompt.generate": "一键生成",
-    "prompt.generating": "生成中...",
-    "prompt.keyboardHint": "提示：按 Alt+Enter 也可触发生成",
-
-    "params.title": "参数覆盖",
-    "params.subtitle": "调整下次渲染时的关键参数，提交请求前会自动合并并交由后端校验",
-    "params.tempo": "速度 (BPM)",
-    "params.meter": "拍号",
-    "params.key": "调性",
-    "params.mode": "调式",
-    "params.instrumentation": "配器列表",
-    "params.instrumentationHint": "使用逗号分隔，Enter 提交；保留空白表示沿用后端解析结果",
-    "params.harmonyOptions": "和声选项",
-    "params.secondaryDominant": "启用二级属和声",
-    "params.reset": "重置为解析结果",
-    "params.resetHint": "撤销前端覆盖，回到最新的后端数据",
-    "params.sliderAria": "使用方向键可按步长微调",
-
-    "form.title": "曲式段落表",
-    "form.subtitle": "Enter 进入编辑，Esc 取消，方向键在单元格间导航",
-    "form.empty": "生成后可在此查看曲式段落，并对每段进行细节调整。",
-    "form.column.section": "段落",
-    "form.column.bars": "小节数",
-    "form.column.tension": "张力",
-    "form.column.motif": "动机标签",
-    "form.column.freeze": "冻结",
-    "form.column.actions": "操作",
-    "form.validation.bars": "请输入 1-128 之间的整数",
-    "form.validation.tension": "请输入 0-100 之间的整数",
-    "form.validation.motif": "动机标签不能为空",
-    "form.freezeSelected": "冻结选中的动机",
-    "form.freezeHint": "冻结后后端不会再替换对应动机，可批量勾选后执行",
-    "form.regenerateMode": "再生成模式",
-    "form.regenerateMelodyOnly": "仅旋律",
-    "form.regenerateMelodyHarmony": "旋律+和声",
-    "form.regenerate": "局部再生成",
-    "form.keyboardHelp": "说明：Focus 在单元格时按 Enter 开始编辑，编辑完成后 Enter 保存，Esc 取消。",
-    "form.frozenTag": "已冻结",
-
-    "player.title": "在线播放预览",
-    "player.subtitle": "提示：浏览器首次播放需用户交互以解除静音策略",
-    "player.noMidi": "暂无可播放的 MIDI，请先进行一次生成或渲染。",
-    "player.play": "播放",
-    "player.pause": "暂停",
-    "player.loop": "循环播放",
-    "player.loopActive": "循环中",
-    "player.seekLabel": "拖动定位",
-    "player.elapsed": "当前",
-    "player.duration": "总长",
-    "player.loading": "正在解析 MIDI...",
-    "player.error": "MIDI 解析失败，请检查下载文件是否存在",
-    "player.muteHint": "若听不到声音，请确认系统音量或浏览器是否静音",
-
-    "piano.title": "Piano-Roll 可视化",
-    "piano.subtitle": "悬停查看音符信息，点击时间轴可与播放器联动",
-    "piano.noData": "暂无音符数据，可生成后查看主旋律轨迹。",
-    "piano.zoom": "时间缩放",
-    "piano.clickToSeek": "点击任意位置可跳转播放进度",
-    "piano.hoverPitch": "音高",
-    "piano.hoverDuration": "时值",
-    "piano.hoverStart": "起始",
-    "piano.limitations": "提示：若音符数量很多，可降低缩放倍率或拖动滚动条查看；当前仅展示音高与时值，不含力度。",
-
-    "download.title": "文件与工程管理",
-    "download.subtitle": "下载按钮仅提供链接，不会将任何 .mid/.json 纳入仓库",
-    "download.midi": "下载 MIDI",
-    "download.json": "下载 JSON",
-    "download.copyJson": "复制骨架 JSON",
-    "download.copySuccess": "已复制到剪贴板",
-    "download.copyFail": "复制失败，请检查浏览器权限",
-    "download.exportView": "导出当前视图设置",
-    "download.viewSaved": "视图设置已保存到本地",
-    "download.viewHint": "包含 Piano-Roll 缩放、主题与语言偏好",
-    "download.projectPlaceholder": "工程名称，如 city_night_v1",
-    "download.save": "保存工程",
-    "download.load": "载入工程",
-
-    "json.title": "生成摘要",
-    "json.trackStats": "轨道统计",
-    "json.projectSpec": "ProjectSpec",
-    "json.toggleOpen": "展开 JSON",
-    "json.toggleClose": "折叠 JSON",
-    "json.empty": "等待生成...",
-
-    "logs.title": "操作日志 (最近 10 条)",
-    "logs.empty": "尚无日志，触发生成或渲染后可在此查看状态。",
-    "logs.clear": "清空日志",
-
-    "alert.error": "错误",
-
-    "log.generateStart": "开始根据 Prompt 生成骨架",
-    "log.generateSuccess": "生成成功，已获取最新 ProjectSpec",
-    "log.generateError": "生成失败",
-    "log.renderOverride": "已根据覆盖参数重新渲染",
-    "log.renderError": "重新渲染失败",
-    "log.regenerateStart": "开始局部再生成",
-    "log.regenerateSuccess": "局部再生成完成",
-    "log.regenerateError": "局部再生成失败",
-    "log.freezeStart": "正在冻结选中的动机",
-    "log.freezeSuccess": "动机冻结完成",
-    "log.freezeError": "冻结动机失败",
-    "log.saveStart": "正在保存工程",
-    "log.saveSuccess": "工程保存完成",
-    "log.saveError": "保存工程失败",
-    "log.loadStart": "正在载入工程",
-    "log.loadSuccess": "工程载入完成",
-    "log.loadError": "载入工程失败",
-    "log.midiParseError": "解析 MIDI 失败，Piano-Roll 将暂不可用",
-    "log.viewSaved": "视图设置已写入 localStorage",
-  },
   en: {
     "status.running": "Running",
     "status.idle": "Idle",
     "status.backendHealthy": "Backend healthy",
     "status.backendIssue": "Backend unreachable",
-    "status.lastChecked": "Last check",
+    "status.lastChecked": "Last checked",
     "status.version": "Backend version",
     "status.environment": "API base",
     "status.language": "Language",
@@ -158,47 +24,48 @@ export const dictionary = {
     "status.refresh": "Refresh health",
     "status.healthChecking": "Checking...",
     "status.healthError": "Unable to reach backend",
+    "status.englishOnly": "English Only",
 
     "prompt.title": "Prompt",
-    "prompt.subtitle": "Describe mood/instrumentation/length. Use Tab to move across controls.",
-    "prompt.templates": "Templates",
-    "prompt.placeholder": "e.g. Lo-Fi at night with piano and strings",
+    "prompt.subtitle": "Describe your musical idea: mood, instrumentation, length, and highlights.",
+    "prompt.templates": "Prompt Templates",
+    "prompt.placeholder": "Enter your musical prompt here...",
     "prompt.generate": "Generate",
     "prompt.generating": "Generating...",
-    "prompt.keyboardHint": "Tip: press Alt+Enter to trigger generation",
+    "prompt.keyboardHint": "Tip: Press Alt+Enter to generate",
 
-    "params.title": "Parameter overrides",
-    "params.subtitle": "Adjust values for the next render. Overrides are merged then validated by the backend.",
+    "params.title": "Parameter Overrides",
+    "params.subtitle": "Adjust key values for the next render. Overrides are merged then validated by the backend.",
     "params.tempo": "Tempo (BPM)",
     "params.meter": "Meter",
     "params.key": "Key",
     "params.mode": "Mode",
-    "params.instrumentation": "Instrumentation",
-    "params.instrumentationHint": "Comma separated list. Leave empty to keep backend defaults.",
-    "params.harmonyOptions": "Harmony options",
-    "params.secondaryDominant": "Enable secondary dominant",
-    "params.reset": "Reset to parsed result",
+    "params.instrumentation": "Instruments",
+    "params.instrumentationHint": "Use commas to separate instruments. Leave empty to keep backend defaults.",
+    "params.harmonyOptions": "Harmony Options",
+    "params.secondaryDominant": "Enable Secondary Dominant",
+    "params.reset": "Reset to Parsed Result",
     "params.resetHint": "Drop local overrides and use the latest backend values",
-    "params.sliderAria": "Use arrow keys to fine tune",
+    "params.sliderAria": "Use arrow keys for fine adjustments",
 
-    "form.title": "Form table",
-    "form.subtitle": "Press Enter to edit, Esc to cancel, arrow keys to move",
-    "form.empty": "Generate to see structural sections and tweak details here.",
+    "form.title": "Form Structure",
+    "form.subtitle": "Press Enter to edit, Esc to cancel, and use arrow keys to move between cells.",
+    "form.empty": "Generate to see section data and tweak details here.",
     "form.column.section": "Section",
     "form.column.bars": "Bars",
     "form.column.tension": "Tension",
     "form.column.motif": "Motif",
     "form.column.freeze": "Freeze",
-    "form.column.actions": "Actions",
+    "form.column.actions": "Action",
     "form.validation.bars": "Enter an integer between 1 and 128",
     "form.validation.tension": "Enter an integer between 0 and 100",
     "form.validation.motif": "Motif label is required",
-    "form.freezeSelected": "Freeze selected motifs",
+    "form.freezeSelected": "Freeze Selected Motifs",
     "form.freezeHint": "Frozen motifs won't be replaced during regeneration. Select rows then apply.",
-    "form.regenerateMode": "Regeneration mode",
-    "form.regenerateMelodyOnly": "Melody only",
-    "form.regenerateMelodyHarmony": "Melody + harmony",
-    "form.regenerate": "Regenerate",
+    "form.regenerateMode": "Regeneration Mode",
+    "form.regenerateMelodyOnly": "Melody Only",
+    "form.regenerateMelodyHarmony": "Melody + Harmony",
+    "form.regenerate": "Regenerate Section",
     "form.keyboardHelp": "Tip: focus a cell and press Enter to edit. Press Enter again to commit or Esc to cancel.",
     "form.frozenTag": "Frozen",
 
@@ -217,7 +84,7 @@ export const dictionary = {
     "player.muteHint": "If no sound plays, check system volume or browser mute settings.",
 
     "piano.title": "Piano roll",
-    "piano.subtitle": "Hover to inspect notes. Click timeline to sync with the player.",
+    "piano.subtitle": "Hover to inspect notes. Click the timeline to sync with the player.",
     "piano.noData": "No note data yet. Generate a project to inspect the melody track.",
     "piano.zoom": "Time zoom",
     "piano.clickToSeek": "Click to jump to a position",
@@ -226,28 +93,28 @@ export const dictionary = {
     "piano.hoverStart": "Start",
     "piano.limitations": "Tip: with many notes, lower the zoom or scroll around. Only pitch and duration are rendered.",
 
-    "download.title": "Downloads & project",
-    "download.subtitle": "Downloads are links only; no MIDI/JSON will enter the repository.",
+    "download.title": "Downloads & Project",
+    "download.subtitle": "Download links only; no MIDI/JSON files are stored in the repository.",
     "download.midi": "Download MIDI",
     "download.json": "Download JSON",
     "download.copyJson": "Copy project JSON",
     "download.copySuccess": "Copied to clipboard",
     "download.copyFail": "Copy failed. Check clipboard permissions.",
-    "download.exportView": "Export view settings",
+    "download.exportView": "Export View Settings",
     "download.viewSaved": "View settings saved locally",
-    "download.viewHint": "Includes piano roll zoom, theme and language",
-    "download.projectPlaceholder": "Project name, e.g. city_night_v1",
-    "download.save": "Save project",
-    "download.load": "Load project",
+    "download.viewHint": "Includes piano roll zoom and theme preferences.",
+    "download.projectPlaceholder": "Project name (e.g. city_night_v1)",
+    "download.save": "Save Project",
+    "download.load": "Load Project",
 
     "json.title": "Summary",
-    "json.trackStats": "Track stats",
-    "json.projectSpec": "Project spec",
+    "json.trackStats": "Track Stats",
+    "json.projectSpec": "Project Spec",
     "json.toggleOpen": "Expand JSON",
     "json.toggleClose": "Collapse JSON",
     "json.empty": "Waiting for data...",
 
-    "logs.title": "Activity log (latest 10)",
+    "logs.title": "Activity Log (Latest 10)",
     "logs.empty": "No activity yet. Generate or render to populate logs.",
     "logs.clear": "Clear logs",
 
@@ -263,19 +130,19 @@ export const dictionary = {
     "log.regenerateError": "Section regeneration failed",
     "log.freezeStart": "Freezing selected motifs",
     "log.freezeSuccess": "Motifs frozen",
-    "log.freezeError": "Freeze motifs failed",
+    "log.freezeError": "Failed to freeze motifs",
     "log.saveStart": "Saving project",
-    "log.saveSuccess": "Project saved",
-    "log.saveError": "Save project failed",
+    "log.saveSuccess": "Project saved successfully",
+    "log.saveError": "Failed to save project",
     "log.loadStart": "Loading project",
-    "log.loadSuccess": "Project loaded",
-    "log.loadError": "Load project failed",
+    "log.loadSuccess": "Project loaded successfully",
+    "log.loadError": "Failed to load project",
     "log.midiParseError": "Failed to parse MIDI. Piano roll disabled.",
     "log.viewSaved": "View settings stored in localStorage",
   },
 } as const;
 
-export type TranslationKey = keyof typeof dictionary.zh;
+export type TranslationKey = keyof typeof dictionary.en;
 
 interface I18nContextValue {
   lang: Lang;
@@ -286,22 +153,23 @@ interface I18nContextValue {
 
 const I18nContext = createContext<I18nContextValue | null>(null);
 
-const STORAGE_KEY = "motifmaker.lang"; // localStorage 键，持久化语言偏好。
+const STORAGE_KEY = "motifmaker.lang"; // 仍写入 localStorage，便于未来恢复多语言时沿用同一键值。
 
 /**
  * Provider 负责持久化语言设置、更新 <html lang> 属性，并向下游暴露 t() 函数。
+ * 当前仅有英文语言，但保留状态与 setter，方便后续扩展其它语言包。
  */
 export const I18nProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const detectDefault = useCallback((): Lang => {
+    // 即使未来新增语言，也可在此读取 localStorage 或浏览器偏好；当前直接回退到英文。
     if (typeof window === "undefined") {
-      return "zh"; // SSR 场景兜底使用中文。
+      return "en";
     }
-    const stored = window.localStorage.getItem(STORAGE_KEY) as Lang | null;
-    if (stored === "zh" || stored === "en") {
-      return stored;
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored && stored in dictionary) {
+      return stored as Lang;
     }
-    const navigatorLang = window.navigator.language.toLowerCase();
-    return navigatorLang.startsWith("zh") ? "zh" : "en";
+    return "en";
   }, []);
 
   const [lang, setLangState] = useState<Lang>(detectDefault);
@@ -309,19 +177,19 @@ export const I18nProvider: React.FC<{ children: React.ReactNode }> = ({ children
   useEffect(() => {
     if (typeof window !== "undefined") {
       window.localStorage.setItem(STORAGE_KEY, lang);
-      document.documentElement.lang = lang === "zh" ? "zh-CN" : "en";
+      document.documentElement.lang = "en"; // 固定 HTML lang 属性为英文，保障可访问性。
     }
   }, [lang]);
 
   const setLang = useCallback((next: Lang) => {
+    // 当前仅支持英文，但保留 setter 以便未来新增语言时直接复用该接口。
     setLangState(next);
   }, []);
 
   const translate = useCallback(
     (key: TranslationKey, vars?: Record<string, string | number>) => {
-      const table = dictionary[lang] ?? dictionary.zh;
-      const fallback = dictionary.zh;
-      const template = table[key] ?? fallback[key] ?? key;
+      const table = dictionary[lang] ?? dictionary.en; // 永远回退到英文，避免缺失时渲染原 key。
+      const template = table[key] ?? key;
       if (!vars) {
         return template;
       }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -11,13 +11,14 @@ import { I18nProvider } from "./i18n"; // 引入轻量级多语言 Provider，�
 const rootElement = document.getElementById("root");
 
 if (!rootElement) {
-  throw new Error("未找到 #root 节点，无法启动前端应用。");
+  // 运行时异常也统一改为英文提示，避免打包后仍出现中文文案。
+  throw new Error("Failed to locate #root element. Unable to bootstrap the web app.");
 }
 
 // createRoot 会启用 React 18 的并发特性，提升交互体验。
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
-    {/* 通过 I18nProvider 包裹 App，提供 t()/setLang 等函数与状态。*/}
+    {/* 通过 I18nProvider 包裹 App，提供 t() 等接口；当前仅启用英文语言包以统一界面。*/}
     <I18nProvider>
       <App />
     </I18nProvider>


### PR DESCRIPTION
## Summary
- consolidate the web i18n layer around a single English dictionary and remove the runtime language selector
- update prompts, default content, and error messaging to English across the app while documenting the English-only mode
- add a consistency script to flag Chinese characters in component source and refresh deployment docs with localization guidance

## Testing
- npm run typecheck
- node web/scripts/check_i18n_consistency.ts

------
https://chatgpt.com/codex/tasks/task_e_68e60a5397608328ae76c748d02e2d31