### PR TITLE
feat: redesign web flow with metal themed steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ Prompt → 解析层(parsing) → 骨架JSON(schema) → 动机生成(motif)
   - 若请求失败，Shoelace `<sl-alert>` 会在顶部出现错误提示，常见原因包括跨域配置或后端服务未启动。
   - MIDI 解析失败会在日志区提示，可下载文件手动导入 DAW 检查。
 
+## 🎨 New UI Flow (Version 0.3)
+- Black-Red Metal Theme
+- Step-by-Step Music Generation
+  1. Motif → 2. Melody → 3. MIDI → 4. Mix → 5. Final Track
+- Mixing step currently simulated; future versions will include audio rendering (API integration planned)
+
 ### 典型操作流程
 1. 在 Web UI 输入 Prompt 并点击“生成”。
 2. 试听或下载返回的 MIDI；必要时保存工程以便下次载入。

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,606 +1,226 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import PromptPanel from "./components/PromptPanel";
-import ParamsPanel from "./components/ParamsPanel";
-import FormTable, { RegenerateMode } from "./components/FormTable";
-import Player from "./components/Player";
-import DownloadBar from "./components/DownloadBar";
-import PianoRoll, { PianoRollNote } from "./components/PianoRoll";
-import TopStatusBar from "./components/TopStatusBar";
+import React, { useCallback, useMemo, useState } from "react";
+import StepIndicator, { StepDefinition } from "./components/StepIndicator";
+import MotifPanel from "./components/steps/MotifPanel";
+import MelodyPanel from "./components/steps/MelodyPanel";
+import MidiPanel from "./components/steps/MidiPanel";
+import MixPanel, { MixSettings } from "./components/steps/MixPanel";
+import RenderPanel from "./components/steps/RenderPanel";
 import {
-  ParamOverrides,
-  ProjectSpec,
-  RenderSuccess,
-  freezeMotif,
   generate,
-  loadProject,
-  mergeSpecWithOverrides,
-  regenerateSection,
   renderProject,
+  requestMix,
   resolveAssetUrl,
-  saveProject,
+  RenderSuccess,
 } from "./api";
-import { useI18n, TranslationKey } from "./hooks/useI18n";
-import { Midi } from "@tonejs/midi";
-
-interface RequestState {
-  loading: boolean;
-  error: string | null;
-}
-
-interface AlertMessage {
-  id: number;
-  message: string;
-}
-
-interface LogEntry {
-  id: number;
-  key: TranslationKey;
-  level: "info" | "success" | "error";
-  timestamp: number;
-  extra?: string;
-}
-
-const VIEW_STORAGE_KEY = "motifmaker.viewSettings";
-const THEME_STORAGE_KEY = "motifmaker.theme";
-
-// 统一默认 Prompt 为英文示例，避免初次加载时出现中文提示文案。
-const DEFAULT_PROMPT =
-  "Gentle night cityscape, warm but restrained, B section peak tension, modern classical + electronic, about 2 minutes";
 
 /**
- * App 组件：整合前端所有功能模块，管理请求状态与布局。
- * - 左侧为 Prompt 与参数覆盖，右侧包含下载、播放器、Piano-Roll 与段落表格；
- * - 顶部状态条轮询健康信息，底部日志区记录最近操作；
- * - 通过 AbortController 及请求状态避免竞态，保障 UI 可预期。
+ * App 组件：Round E 金属主题界面与分阶段音乐生成流程的核心容器。
+ * - 顶部展示步骤导航，底部提供状态栏与进度条；
+ * - 内部分为五个阶段：Motif → Melody → MIDI → Mixing → Final Track；
+ * - 每个阶段完成后才会自动解锁下一阶段，确保流程结构化。
  */
+const steps: StepDefinition[] = [
+  { id: 1, label: "Motif" },
+  { id: 2, label: "Melody" },
+  { id: 3, label: "MIDI" },
+  { id: 4, label: "Mixing" },
+  { id: 5, label: "Final Track" },
+];
+
+const DEFAULT_PROMPT =
+  "Forged synth metal intro, hybrid orchestra hits, halftime breakdown, neon skyline energy";
+
 const App: React.FC = () => {
-  const { t } = useI18n();
-  const [promptText, setPromptText] = useState(DEFAULT_PROMPT);
-  const [baseSpec, setBaseSpec] = useState<ProjectSpec | null>(null); // 后端权威 ProjectSpec，表格编辑直接更新该状态。
-  const [lastRender, setLastRender] = useState<RenderSuccess | null>(null); // 最近一次渲染结果，驱动下载与播放器。
-  const [overrides, setOverrides] = useState<ParamOverrides>({}); // 参数覆盖集合，下次请求前会合并到 baseSpec。
-  const [generateState, setGenerateState] = useState<RequestState>({ loading: false, error: null }); // /generate 状态。
-  const [renderState, setRenderState] = useState<RequestState>({ loading: false, error: null }); // 覆盖参数触发的二次渲染状态。
-  const [regenerateState, setRegenerateState] = useState<RequestState>({ loading: false, error: null }); // /regenerate-section 状态。
-  const [saveState, setSaveState] = useState<RequestState>({ loading: false, error: null }); // /save-project 状态。
-  const [loadState, setLoadState] = useState<RequestState>({ loading: false, error: null }); // /load-project 状态。
-  const [freezeState, setFreezeState] = useState<RequestState>({ loading: false, error: null }); // /freeze-motif 状态。
-  const [alerts, setAlerts] = useState<AlertMessage[]>([]); // Shoelace sl-alert 队列，展示错误提示。
-  const alertIdRef = useRef(0);
-  const [logs, setLogs] = useState<LogEntry[]>([]); // 最近 10 条操作日志。
-  const logIdRef = useRef(0);
-  const [jsonCollapsed, setJsonCollapsed] = useState(false);
-  const [pianoNotes, setPianoNotes] = useState<PianoRollNote[]>([]); // Piano-Roll 绘制的音符列表。
-  const [playbackTime, setPlaybackTime] = useState(0); // 播放器当前秒数。
-  const [playerDuration, setPlayerDuration] = useState(0); // 播放器解析到的曲目总长。
-  const [pendingSeek, setPendingSeek] = useState<number | null>(null); // 来自 Piano-Roll 的定位请求。
-  const [exportingView, setExportingView] = useState(false); // 导出视图设置时的加载状态。
+  const [step, setStep] = useState<number>(1); // 当前步骤索引。
+  const [prompt, setPrompt] = useState<string>(DEFAULT_PROMPT); // Motif 生成使用的 Prompt。
+  const [motifState, setMotifState] = useState<RenderSuccess | null>(null); // 保存后端生成的完整规格。
+  const [motifLoading, setMotifLoading] = useState(false); // Motif 生成的加载态。
+  const [motifError, setMotifError] = useState<string | null>(null); // Motif 生成的错误文案。
 
-  const initialScale = useMemo(() => {
-    if (typeof window === "undefined") return 120;
+  const [melodyNotes, setMelodyNotes] = useState<string>(""); // Melody 阶段记录的旋律笔记。
+  const [melodyLocked, setMelodyLocked] = useState(false); // Melody 阶段是否已经确认。
+
+  const [arrangementNotes, setArrangementNotes] = useState<string>(""); // MIDI 阶段的结构规划。
+  const [arrangementLoading, setArrangementLoading] = useState(false); // MIDI 渲染加载态。
+  const [arrangementError, setArrangementError] = useState<string | null>(null); // MIDI 渲染错误。
+  const [midiUrl, setMidiUrl] = useState<string | null>(null); // 最新的 MIDI 下载地址。
+
+  const [mixSettings, setMixSettings] = useState<MixSettings>({
+    reverb: 35,
+    pan: 0,
+    volume: -6,
+    preset: "metal-suite",
+  }); // 混音参数集合。
+  const [mixLoading, setMixLoading] = useState(false); // 混音阶段加载态。
+  const [mixError, setMixError] = useState<string | null>(null); // 混音阶段错误提示。
+  const [audioUrl, setAudioUrl] = useState<string | null>(null); // 最终音频地址。
+
+  const [projectId] = useState<string>(() => {
+    // 使用时间戳生成项目 ID，保证界面刷新前保持稳定。
+    return `MM-${Date.now().toString(36).toUpperCase()}`;
+  });
+
+  const projectTitle = motifState?.project?.title ?? null;
+  const motifSummary = motifState?.summary ?? null;
+
+  const progress = useMemo(() => step / steps.length, [step]); // 计算底部进度条比例。
+
+  const handleMotifGenerate = useCallback(async () => {
+    setMotifLoading(true);
+    setMotifError(null);
     try {
-      const stored = window.localStorage.getItem(VIEW_STORAGE_KEY);
-      if (stored) {
-        const parsed = JSON.parse(stored);
-        if (typeof parsed.pianoScale === "number") {
-          return parsed.pianoScale;
-        }
-      }
+      const result = await generate(prompt);
+      setMotifState(result);
+      setMidiUrl(resolveAssetUrl(result.midi));
+      setStep(2);
     } catch (error) {
-      console.warn("failed to read view settings", error);
+      const message = (error as Error).message || "Failed to generate motif. Please retry.";
+      setMotifError(message);
+    } finally {
+      setMotifLoading(false);
     }
-    return 120;
-  }, []); // 读取本地存储的 Piano-Roll 缩放倍率，便于跨会话保持视图。
-  const [pianoScale, setPianoScale] = useState<number>(initialScale);
+  }, [prompt]);
 
-  const initialTheme = useMemo(() => {
-    if (typeof window === "undefined") return "dark" as const;
-    const stored = window.localStorage.getItem(THEME_STORAGE_KEY) as "light" | "dark" | null;
-    if (stored === "light" || stored === "dark") {
-      return stored;
-    }
-    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-  }, []); // 主题默认读取 localStorage，若无记录则依据系统偏好。
-  const [theme, setTheme] = useState<"light" | "dark">(initialTheme);
-
-  useEffect(() => {
-    if (typeof document !== "undefined") {
-      document.documentElement.classList.toggle("dark", theme === "dark");
-    }
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem(THEME_STORAGE_KEY, theme);
-    }
-  }, [theme]);
-
-  const generateController = useRef<AbortController | null>(null);
-  const regenerateController = useRef<AbortController | null>(null);
-  const saveController = useRef<AbortController | null>(null);
-  const loadController = useRef<AbortController | null>(null);
-  const freezeController = useRef<AbortController | null>(null);
-
-  useEffect(() => {
-    return () => {
-      generateController.current?.abort();
-      regenerateController.current?.abort();
-      saveController.current?.abort();
-      loadController.current?.abort();
-      freezeController.current?.abort();
-    };
+  const handleMelodyConfirm = useCallback(() => {
+    setMelodyLocked(true);
+    setStep(3);
   }, []);
 
-  const showErrorAlert = useCallback((message: string) => {
-    // 将错误消息推入 alerts 队列，由 Shoelace sl-alert 展示并允许手动关闭。
-    setAlerts((prev) => [...prev, { id: alertIdRef.current++, message }]);
-  }, []);
+  const handleArrange = useCallback(async () => {
+    if (!motifState) {
+      setArrangementError("Generate a motif first.");
+      return;
+    }
+    setArrangementLoading(true);
+    setArrangementError(null);
+    try {
+      const result = await renderProject(motifState.project);
+      setMotifState(result);
+      setMidiUrl(resolveAssetUrl(result.midi));
+      setStep(4);
+    } catch (error) {
+      const message = (error as Error).message || "Failed to arrange MIDI. Please try again.";
+      setArrangementError(message);
+    } finally {
+      setArrangementLoading(false);
+    }
+  }, [motifState]);
 
-  const appendLog = useCallback(
-    (key: TranslationKey, level: "info" | "success" | "error", extra?: string) => {
-      // 日志仅保留最近 10 条，存储翻译 key 以便语言切换时自动更新文案。
-      setLogs((prev) => [
-        {
-          id: logIdRef.current++,
-          key,
-          level,
-          timestamp: Date.now(),
-          extra,
-        },
-        ...prev,
-      ].slice(0, 10));
-    },
-    []
-  );
-
-  const effectiveSpec = useMemo(() => {
-    if (!baseSpec) return null;
-    return mergeSpecWithOverrides(baseSpec, overrides);
-  }, [baseSpec, overrides]);
-
-  const midiUrl = useMemo(() => resolveAssetUrl(lastRender?.midi ?? null), [lastRender]);
-  const jsonUrl = useMemo(() => resolveAssetUrl(lastRender?.spec ?? null), [lastRender]);
-
-  const trackStatsJson = useMemo(() => {
-    if (!lastRender) return t("json.empty");
-    return JSON.stringify(lastRender.track_stats, null, 2);
-  }, [lastRender, t]);
-
-  const projectJson = useMemo(() => {
-    if (!effectiveSpec) return "{}";
-    return JSON.stringify(effectiveSpec, null, 2);
-  }, [effectiveSpec]);
-
-  const isBusy =
-    generateState.loading ||
-    renderState.loading ||
-    regenerateState.loading ||
-    saveState.loading ||
-    loadState.loading ||
-    freezeState.loading;
-
-  const lastErrorMessage =
-    generateState.error ||
-    renderState.error ||
-    regenerateState.error ||
-    saveState.error ||
-    loadState.error ||
-    freezeState.error;
-
-  const handleOverridesChange = useCallback((next: ParamOverrides) => {
-    setOverrides(next);
-  }, []);
-
-  const handleResetOverrides = useCallback(() => {
-    setOverrides({});
-  }, []);
-
-  const handleUpdateSection = useCallback(
-    (index: number, updates: Partial<ProjectSpec["form"][number]>) => {
-      setBaseSpec((prev) => {
-        if (!prev) return prev;
-        const form = prev.form.map((section, idx) =>
-          idx === index ? { ...section, ...updates } : section
-        );
-        return { ...prev, form };
+  const handleMixPreview = useCallback(async () => {
+    if (!motifState?.midi) {
+      setMixError("Arrange a MIDI file before mixing.");
+      return;
+    }
+    setMixLoading(true);
+    setMixError(null);
+    try {
+      const response = await requestMix({
+        midi_path: motifState.midi,
+        reverb: mixSettings.reverb,
+        pan: mixSettings.pan,
+        volume: mixSettings.volume,
+        preset: mixSettings.preset,
       });
-    },
-    []
-  );
-
-  const parseMidiForRoll = useCallback(
-    async (url: string) => {
-      // 解析 MIDI 用于 Piano-Roll 展示，取音符数量最多的轨作为主旋律轨迹。
-      try {
-        const response = await fetch(url);
-        const buffer = await response.arrayBuffer();
-        const midi = new Midi(buffer);
-        const richestTrack = midi.tracks.reduce((best, track) => {
-          if (!best || track.notes.length > best.notes.length) {
-            return track;
-          }
-          return best;
-        }, midi.tracks[0]);
-        const notes: PianoRollNote[] = (richestTrack?.notes ?? []).map((note) => ({
-          pitch: note.midi,
-          start: note.time,
-          duration: note.duration,
-          velocity: note.velocity,
-        }));
-        setPianoNotes(notes);
-        setPlayerDuration(midi.duration);
-      } catch (error) {
-        console.error("failed to parse midi for piano roll", error);
-        appendLog("log.midiParseError", "error");
-        showErrorAlert(t("player.error"));
-      }
-    },
-    [appendLog, showErrorAlert, t]
-  );
-
-  useEffect(() => {
-    const url = midiUrl;
-    if (!url) {
-      setPianoNotes([]);
-      setPlayerDuration(0); // 清空可视化时也重置时长，避免显示旧数据。
-      setPlaybackTime(0);
-      return;
-    }
-    parseMidiForRoll(url);
-  }, [midiUrl, parseMidiForRoll]);
-
-  const handleGenerate = useCallback(async () => {
-    // 一键生成：若存在历史请求则取消，通过 overrides 判断是否需要额外渲染。
-    generateController.current?.abort();
-    const controller = new AbortController();
-    generateController.current = controller;
-    setGenerateState({ loading: true, error: null });
-    appendLog("log.generateStart", "info");
-    try {
-      const result = await generate(promptText, controller.signal);
-      if (controller.signal.aborted) return;
-      appendLog("log.generateSuccess", "success");
-      setBaseSpec(result.project);
-      setLastRender(result);
-      if (Object.keys(overrides).length > 0) {
-        setRenderState({ loading: true, error: null });
-        const merged = mergeSpecWithOverrides(result.project, overrides);
-        try {
-          const renderResult = await renderProject(merged, controller.signal);
-          if (controller.signal.aborted) {
-            setRenderState({ loading: false, error: null });
-            return;
-          }
-          setBaseSpec(renderResult.project);
-          setLastRender(renderResult);
-          appendLog("log.renderOverride", "info");
-          setRenderState({ loading: false, error: null });
-        } catch (error) {
-          if ((error as Error).name === "AbortError") return;
-          const message = (error as Error).message;
-          setRenderState({ loading: false, error: message });
-          appendLog("log.renderError", "error", message);
-          showErrorAlert(message);
-        }
-      } else {
-        setRenderState({ loading: false, error: null });
-      }
+      const resolved = resolveAssetUrl(response.wave_url);
+      setAudioUrl(resolved);
+      setStep(5);
     } catch (error) {
-      if ((error as Error).name === "AbortError") return;
-      const message = (error as Error).message;
-      setGenerateState({ loading: false, error: message });
-      appendLog("log.generateError", "error", message);
-      showErrorAlert(message);
-      return;
+      const message = (error as Error).message || "Mixing preview failed. Check the backend logs.";
+      setMixError(message);
     } finally {
-      if (!controller.signal.aborted) {
-        setGenerateState((prev) => ({ ...prev, loading: false }));
-      }
+      setMixLoading(false);
     }
-  }, [appendLog, overrides, promptText, showErrorAlert]);
+  }, [mixSettings, motifState]);
 
-  const handleRegenerateSection = useCallback(
-    async (index: number, mode: RegenerateMode) => {
-      // 局部再生成：合并参数覆盖并根据模式决定是否保留动机，使用 AbortController 避免竞态。
-      if (!baseSpec) return;
-      regenerateController.current?.abort();
-      const controller = new AbortController();
-      regenerateController.current = controller;
-      setRegenerateState({ loading: true, error: null });
-      appendLog("log.regenerateStart", "info");
-      try {
-        const specForRequest = mergeSpecWithOverrides(baseSpec, overrides);
-        const keepMotif = mode === "melody";
-        const result = await regenerateSection(
-          specForRequest,
-          index,
-          keepMotif,
-          controller.signal
+  const renderStage = () => {
+    switch (step) {
+      case 1:
+        return (
+          <MotifPanel
+            prompt={prompt}
+            onPromptChange={setPrompt}
+            onGenerate={handleMotifGenerate}
+            loading={motifLoading}
+            error={motifError}
+            summary={motifSummary}
+            projectTitle={projectTitle}
+          />
         );
-        if (controller.signal.aborted) return;
-        setBaseSpec(result.project);
-        setLastRender(result);
-        appendLog("log.regenerateSuccess", "success");
-        setRegenerateState({ loading: false, error: null });
-      } catch (error) {
-        if ((error as Error).name === "AbortError") return;
-        const message = (error as Error).message;
-        setRegenerateState({ loading: false, error: message });
-        appendLog("log.regenerateError", "error", message);
-        showErrorAlert(message);
-        return;
-      } finally {
-        if (!controller.signal.aborted) {
-          setRegenerateState((prev) => ({ ...prev, loading: false }));
-        }
-      }
-    },
-    [appendLog, baseSpec, overrides, showErrorAlert]
-  );
-
-  const handleFreezeMotifs = useCallback(
-    async (motifTags: string[]) => {
-      // 批量冻结动机：提交当前覆盖后的 ProjectSpec 与勾选的标签。
-      if (!baseSpec || motifTags.length === 0) return;
-      freezeController.current?.abort();
-      const controller = new AbortController();
-      freezeController.current = controller;
-      setFreezeState({ loading: true, error: null });
-      appendLog("log.freezeStart", "info");
-      try {
-        const specForRequest = mergeSpecWithOverrides(baseSpec, overrides);
-        const result = await freezeMotif(specForRequest, motifTags, controller.signal);
-        if (controller.signal.aborted) return;
-        setBaseSpec(result.project);
-        appendLog("log.freezeSuccess", "success");
-        setFreezeState({ loading: false, error: null });
-      } catch (error) {
-        if ((error as Error).name === "AbortError") return;
-        const message = (error as Error).message;
-        setFreezeState({ loading: false, error: message });
-        appendLog("log.freezeError", "error", message);
-        showErrorAlert(message);
-        return;
-      } finally {
-        if (!controller.signal.aborted) {
-          setFreezeState((prev) => ({ ...prev, loading: false }));
-        }
-      }
-    },
-    [appendLog, baseSpec, overrides, showErrorAlert]
-  );
-
-  const handleSaveProject = useCallback(
-    async (name: string) => {
-      // 保存工程：合并覆盖后写入服务器 projects/ 目录。
-      if (!baseSpec) return;
-      saveController.current?.abort();
-      const controller = new AbortController();
-      saveController.current = controller;
-      setSaveState({ loading: true, error: null });
-      appendLog("log.saveStart", "info");
-      try {
-        const payload = mergeSpecWithOverrides(baseSpec, overrides);
-        await saveProject(payload, name, controller.signal);
-        if (controller.signal.aborted) return;
-        appendLog("log.saveSuccess", "success", name);
-        setSaveState({ loading: false, error: null });
-      } catch (error) {
-        if ((error as Error).name === "AbortError") return;
-        const message = (error as Error).message;
-        setSaveState({ loading: false, error: message });
-        appendLog("log.saveError", "error", message);
-        showErrorAlert(message);
-        return;
-      } finally {
-        if (!controller.signal.aborted) {
-          setSaveState((prev) => ({ ...prev, loading: false }));
-        }
-      }
-    },
-    [appendLog, baseSpec, overrides, showErrorAlert]
-  );
-
-  const handleLoadProject = useCallback(
-    async (name: string) => {
-      // 载入工程：读取服务器端 JSON 并覆盖本地状态，同时清空当前渲染。
-      loadController.current?.abort();
-      const controller = new AbortController();
-      loadController.current = controller;
-      setLoadState({ loading: true, error: null });
-      appendLog("log.loadStart", "info", name);
-      try {
-        const result = await loadProject(name, controller.signal);
-        if (controller.signal.aborted) return;
-        setBaseSpec(result.project);
-        setLastRender(null);
-        appendLog("log.loadSuccess", "success", name);
-        setLoadState({ loading: false, error: null });
-      } catch (error) {
-        if ((error as Error).name === "AbortError") return;
-        const message = (error as Error).message;
-        setLoadState({ loading: false, error: message });
-        appendLog("log.loadError", "error", message);
-        showErrorAlert(message);
-        return;
-      } finally {
-        if (!controller.signal.aborted) {
-          setLoadState((prev) => ({ ...prev, loading: false }));
-        }
-      }
-    },
-    [appendLog, showErrorAlert]
-  );
-
-  const handleExportView = useCallback(async () => {
-    // 导出视图设置：仅写入 Piano-Roll 缩放与主题偏好；语言固定为英文无需持久化。
-    if (typeof window === "undefined") return;
-    setExportingView(true);
-    try {
-      const payload = {
-        pianoScale,
-        theme,
-      };
-      window.localStorage.setItem(VIEW_STORAGE_KEY, JSON.stringify(payload));
-      appendLog("log.viewSaved", "success");
-    } finally {
-      setExportingView(false);
+      case 2:
+        return (
+          <MelodyPanel
+            notes={melodyNotes}
+            onNotesChange={setMelodyNotes}
+            onConfirm={handleMelodyConfirm}
+            disabled={!motifState}
+          />
+        );
+      case 3:
+        return (
+          <MidiPanel
+            arrangement={arrangementNotes}
+            onArrangementChange={setArrangementNotes}
+            onArrange={handleArrange}
+            loading={arrangementLoading}
+            disabled={!melodyLocked}
+            midiUrl={midiUrl}
+            error={arrangementError}
+          />
+        );
+      case 4:
+        return (
+          <MixPanel
+            settings={mixSettings}
+            onSettingsChange={setMixSettings}
+            onPreview={handleMixPreview}
+            loading={mixLoading}
+            disabled={!midiUrl}
+            error={mixError}
+          />
+        );
+      case 5:
+      default:
+        return (
+          <RenderPanel
+            audioUrl={audioUrl}
+            midiUrl={midiUrl}
+            projectTitle={projectTitle}
+            projectId={projectId}
+          />
+        );
     }
-  }, [appendLog, pianoScale, theme]);
-
-  const handlePlayerProgress = useCallback((time: number) => {
-    setPlaybackTime(time);
-  }, []);
-
-  const handlePlayerDuration = useCallback((durationValue: number) => {
-    setPlayerDuration(durationValue);
-  }, []);
-
-  const handleSeekFromRoll = useCallback((time: number) => {
-    setPendingSeek(time);
-    setPlaybackTime(time);
-  }, []);
-
-  const handleAlertClose = useCallback((id: number) => {
-    setAlerts((prev) => prev.filter((item) => item.id !== id));
-  }, []);
+  };
 
   return (
-    <div
-      className={
-        theme === "dark"
-          ? "flex min-h-screen flex-col bg-slate-950 text-slate-100"
-          : "flex min-h-screen flex-col bg-slate-100 text-slate-900"
-      }
-    >
-      <TopStatusBar busy={isBusy} lastError={lastErrorMessage} theme={theme} onThemeChange={setTheme} />
-      <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-6 px-4 py-6">
-        <div className="space-y-2">
-          {alerts.map((alert) => (
-            <sl-alert
-              key={alert.id}
-              variant="danger"
-              open
-              closable
-              onSlAfterHide={() => handleAlertClose(alert.id)}
-            >
-              <span slot="icon">⚠️</span>
-              {alert.message}
-            </sl-alert>
-          ))}
+    <div className="min-h-screen bg-metal-radial pb-24 text-gray-200">
+      <header className="sticky top-0 z-40 border-b border-bloodred/30 bg-black/60 backdrop-blur-xl">
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-6 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-[0.4em] text-bloodred">MotifMaker</p>
+            <h1 className="mt-2 text-3xl font-semibold text-white">Metal Forge Pipeline</h1>
+          </div>
+          <StepIndicator steps={steps} currentStep={step} />
         </div>
-        <div className="grid gap-6 lg:grid-cols-[320px_minmax(0,1fr)]">
-          <div className="space-y-6">
-            <PromptPanel
-              promptText={promptText}
-              onPromptChange={setPromptText}
-              onGenerate={handleGenerate}
-              loading={generateState.loading || renderState.loading}
-            />
-            <ParamsPanel
-              projectSpec={baseSpec}
-              overrides={overrides}
-              onOverridesChange={handleOverridesChange}
-              onResetOverrides={handleResetOverrides}
-              disabled={generateState.loading || renderState.loading}
-            />
-          </div>
-          <div className="space-y-6">
-            <DownloadBar
-              midiUrl={midiUrl}
-              jsonUrl={jsonUrl}
-              projectJson={projectJson}
-              onSaveProject={handleSaveProject}
-              onLoadProject={handleLoadProject}
-              onExportView={handleExportView}
-              saveLoading={saveState.loading}
-              loadLoading={loadState.loading}
-              exportLoading={exportingView}
-            />
-            <Player
-              midiUrl={midiUrl}
-              onProgress={handlePlayerProgress}
-              onDuration={handlePlayerDuration}
-              externalSeek={pendingSeek}
-              onSeekApplied={() => setPendingSeek(null)}
-              onError={(message) => showErrorAlert(message)}
-            />
-            <PianoRoll
-              notes={pianoNotes}
-              duration={playerDuration}
-              currentTime={playbackTime}
-              scale={pianoScale}
-              onScaleChange={setPianoScale}
-              onSeek={handleSeekFromRoll}
-            />
-            <FormTable
-              projectSpec={effectiveSpec}
-              onUpdateSection={handleUpdateSection}
-              onRegenerateSection={handleRegenerateSection}
-              regenerating={regenerateState.loading}
-              onFreezeMotifs={handleFreezeMotifs}
-              freezeLoading={freezeState.loading}
-            />
-            <section className="space-y-3 rounded-lg border border-slate-200 bg-white p-4 text-xs shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:text-slate-100">
-              <header className="flex items-center justify-between">
-                <h3 className="font-semibold">{t("json.title")}</h3>
-                <button
-                  type="button"
-                  className="text-xs text-cyan-500 hover:underline"
-                  onClick={() => setJsonCollapsed((prev) => !prev)}
-                >
-                  {jsonCollapsed ? t("json.toggleOpen") : t("json.toggleClose")}
-                </button>
-              </header>
-              {!jsonCollapsed && (
-                <div className="grid gap-4 lg:grid-cols-2">
-                  <div className="rounded border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-900/60">
-                    <h4 className="mb-2 font-medium text-slate-900 dark:text-slate-100">{t("json.trackStats")}</h4>
-                    <pre className="max-h-72 overflow-auto whitespace-pre-wrap text-slate-800 dark:text-slate-200">{trackStatsJson}</pre>
-                  </div>
-                  <div className="rounded border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-900/60">
-                    <h4 className="mb-2 font-medium text-slate-900 dark:text-slate-100">{t("json.projectSpec")}</h4>
-                    <pre className="max-h-72 overflow-auto whitespace-pre-wrap text-slate-800 dark:text-slate-200">{projectJson}</pre>
-                  </div>
-                </div>
-              )}
-            </section>
-          </div>
+      </header>
+      <main className="mx-auto w-full max-w-6xl px-6 py-10">
+        <div key={step} className="animate-metal-fade">
+          {renderStage()}
         </div>
       </main>
-      <footer className="border-t border-slate-200 bg-slate-50 dark:border-slate-800 dark:bg-slate-950">
-        <div className="mx-auto w-full max-w-7xl px-4 py-4">
-          <div className="flex items-center justify-between gap-2">
-            <h4 className="text-sm font-semibold text-slate-900 dark:text-slate-100">{t("logs.title")}</h4>
-            <button
-              type="button"
-              className="text-xs text-cyan-500 hover:underline"
-              onClick={() => setLogs([])}
-            >
-              {t("logs.clear")}
-            </button>
+      <footer className="fixed bottom-0 left-0 right-0 border-t border-bloodred/30 bg-black/70 backdrop-blur-xl">
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-6 py-4 text-xs uppercase tracking-[0.25em] text-gray-500 md:flex-row md:items-center md:justify-between">
+          <span>Phase {step} of {steps.length}</span>
+          <div className="flex flex-1 items-center gap-4 md:justify-end">
+            <div className="h-1 w-full max-w-xs overflow-hidden rounded-full bg-gray-700">
+              <div
+                className="h-full bg-gradient-to-r from-bloodred via-red-600 to-red-400"
+                style={{ width: `${Math.max(progress, 0.05) * 100}%` }}
+              />
+            </div>
+            <span className="text-sm normal-case tracking-[0.1em] text-gray-300">
+              {steps[Math.min(step - 1, steps.length - 1)].label}
+            </span>
           </div>
-          {logs.length === 0 ? (
-            <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">{t("logs.empty")}</p>
-          ) : (
-            <ul className="mt-2 space-y-1 text-xs">
-              {logs.map((entry) => (
-                <li
-                  key={entry.id}
-                  className={
-                    entry.level === "success"
-                      ? "text-emerald-500"
-                      : entry.level === "error"
-                      ? "text-red-500"
-                      : "text-slate-600 dark:text-slate-300"
-                  }
-                >
-                  <span className="mr-2 text-[11px] text-slate-400 dark:text-slate-500">
-                    {new Date(entry.timestamp).toLocaleTimeString()}
-                  </span>
-                  {t(entry.key)}
-                  {entry.extra ? `：${entry.extra}` : null}
-                </li>
-              ))}
-            </ul>
-          )}
         </div>
       </footer>
     </div>

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -90,6 +90,13 @@ export interface FreezeSuccess {
 }
 
 /**
+ * 混音模拟响应，仅返回占位音频的 URL，后续可接入真实渲染服务。
+ */
+export interface MixSuccess {
+  wave_url: string;
+}
+
+/**
  * /healthz 健康检查响应。
  */
 export interface HealthResponse {
@@ -162,6 +169,10 @@ export function resolveAssetUrl(path: string | null | undefined): string | null 
   if (!path) return null;
   if (/^https?:\/\//i.test(path)) {
     return path; // 后端已返回完整 URL 时无需处理。
+  }
+  if (path.startsWith("/")) {
+    const base = API_BASE.replace(/\/?$/, "");
+    return `${base}${path}`; // 处理以 / 开头的静态资源路径，常见于占位音频。
   }
   const base = API_BASE.replace(/\/?$/, "");
   // 通过 download 端点安全读取输出目录，避免直接暴露文件系统结构。
@@ -330,6 +341,22 @@ export async function loadProject(
     { name },
     signal
   );
+}
+
+/**
+ * 调用 /mix 接口预览混音结果，目前为模拟数据，返回占位波形地址。
+ */
+export async function requestMix(
+  payload: {
+    midi_path: string;
+    reverb: number;
+    pan: number;
+    volume: number;
+    preset: string;
+  },
+  signal?: AbortSignal
+): Promise<MixSuccess> {
+  return postJson<MixSuccess>("/mix", payload, signal);
 }
 
 /**

--- a/web/src/components/StepIndicator.tsx
+++ b/web/src/components/StepIndicator.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import clsx from "clsx";
+
+/**
+ * StepIndicator 组件：顶栏步骤导航，突出当前阶段并告知整体进度。
+ * - 使用红色光条凸显激活步骤；
+ * - 结合金属质感的字体与分隔线，营造工业风格。
+ */
+export interface StepDefinition {
+  id: number;
+  label: string;
+  description?: string;
+}
+
+interface StepIndicatorProps {
+  steps: StepDefinition[];
+  currentStep: number;
+}
+
+const StepIndicator: React.FC<StepIndicatorProps> = ({ steps, currentStep }) => {
+  return (
+    <nav className="flex items-center gap-8 text-xs uppercase tracking-[0.3em] text-gray-400">
+      {steps.map((step, index) => {
+        const isActive = step.id === currentStep;
+        const isCompleted = step.id < currentStep;
+        return (
+          <div
+            key={step.id}
+            className={clsx(
+              "flex flex-col items-center text-center transition-colors duration-200",
+              isActive ? "text-white glow-line" : isCompleted ? "text-gray-200" : "text-gray-500"
+            )}
+          >
+            <div className="text-[0.65rem]">{`${step.id.toString().padStart(2, "0")}/${steps.length}`}</div>
+            <div className="mt-1 font-semibold">{step.label}</div>
+            {index < steps.length - 1 && (
+              <div className="mt-3 h-px w-16 bg-gradient-to-r from-transparent via-bloodred/40 to-transparent" />
+            )}
+          </div>
+        );
+      })}
+    </nav>
+  );
+};
+
+export default StepIndicator;

--- a/web/src/components/steps/MelodyPanel.tsx
+++ b/web/src/components/steps/MelodyPanel.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+/**
+ * MelodyPanel 组件：在动机基础上拓展旋律线条，允许用户撰写与标注想法。
+ * - 使用多行文本域记录旋律片段描述；
+ * - 点击确认按钮后通知上层继续流程。
+ */
+interface MelodyPanelProps {
+  notes: string;
+  onNotesChange: (value: string) => void;
+  onConfirm: () => void;
+  disabled: boolean;
+}
+
+const MelodyPanel: React.FC<MelodyPanelProps> = ({ notes, onNotesChange, onConfirm, disabled }) => {
+  return (
+    <section className="metal-panel rounded-xl p-8 text-sm leading-relaxed">
+      <header className="mb-6 flex flex-col gap-2">
+        <h2 className="text-2xl font-semibold text-white">Melody Builder</h2>
+        <p className="text-sm text-gray-400">
+          Develop the motif into full phrases. Capture contour ideas or lyrical hooks before arranging.
+        </p>
+      </header>
+      <div className="flex flex-col gap-4">
+        <label className="text-xs uppercase tracking-[0.25em] text-gray-500">Melodic Sketch</label>
+        <textarea
+          className="min-h-[200px] rounded-lg border border-gray-700 bg-black/40 p-4 text-sm text-gray-100 outline-none focus:border-bloodred focus:ring-1 focus:ring-bloodred/60"
+          value={notes}
+          onChange={(event) => onNotesChange(event.target.value)}
+          placeholder="Detail how the motif evolves across A/B sections, dynamics, or counter lines."
+        />
+        <button
+          type="button"
+          className="metal-button mt-2 w-full rounded-md px-6 py-3 text-sm"
+          onClick={onConfirm}
+          disabled={disabled || !notes.trim()}
+        >
+          Build Melody
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default MelodyPanel;

--- a/web/src/components/steps/MidiPanel.tsx
+++ b/web/src/components/steps/MidiPanel.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+
+/**
+ * MidiPanel 组件：承接旋律草稿，触发 /render 生成新的 MIDI 结构。
+ * - 允许输入分段与节奏规划；
+ * - 渲染成功后反馈可下载链接，提醒进入混音阶段。
+ */
+interface MidiPanelProps {
+  arrangement: string;
+  onArrangementChange: (value: string) => void;
+  onArrange: () => void;
+  loading: boolean;
+  disabled: boolean;
+  midiUrl: string | null;
+  error?: string | null;
+}
+
+const MidiPanel: React.FC<MidiPanelProps> = ({
+  arrangement,
+  onArrangementChange,
+  onArrange,
+  loading,
+  disabled,
+  midiUrl,
+  error,
+}) => {
+  return (
+    <section className="metal-panel rounded-xl p-8 text-sm leading-relaxed">
+      <header className="mb-6 flex flex-col gap-2">
+        <h2 className="text-2xl font-semibold text-white">MIDI Arranger</h2>
+        <p className="text-sm text-gray-400">
+          Define structure, harmonic density, and transitions. The arranger will consolidate everything into a new MIDI file.
+        </p>
+      </header>
+      <div className="flex flex-col gap-4">
+        <label className="text-xs uppercase tracking-[0.25em] text-gray-500">Arrangement Blueprint</label>
+        <textarea
+          className="min-h-[200px] rounded-lg border border-gray-700 bg-black/40 p-4 text-sm text-gray-100 outline-none focus:border-bloodred focus:ring-1 focus:ring-bloodred/60"
+          value={arrangement}
+          onChange={(event) => onArrangementChange(event.target.value)}
+          placeholder="Describe section flow, percussion layers, or harmonic changes for the arranger."
+        />
+        <button
+          type="button"
+          className="metal-button mt-2 w-full rounded-md px-6 py-3 text-sm"
+          onClick={onArrange}
+          disabled={disabled || loading}
+        >
+          {loading ? "Arranging..." : "Arrange MIDI"}
+        </button>
+        {error && <p className="text-xs text-bloodred">{error}</p>}
+        {midiUrl && (
+          <div className="mt-4 rounded-lg border border-bloodred/30 bg-black/40 p-4 text-xs text-gray-300">
+            <p className="font-semibold text-white">MIDI Ready</p>
+            <p className="mt-2 text-sm text-gray-400">
+              Download the generated MIDI and head into the mixing console when you are satisfied with the structure.
+            </p>
+            <a
+              className="mt-3 inline-flex items-center gap-2 text-sm font-semibold text-bloodred hover:text-red-400"
+              href={midiUrl}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Download Latest MIDI
+            </a>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default MidiPanel;

--- a/web/src/components/steps/MixPanel.tsx
+++ b/web/src/components/steps/MixPanel.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { SlRange, SlSelect, SlOption } from "@shoelace-style/shoelace/dist/react";
+
+/**
+ * MixPanel 组件：模拟混音台调参，提供混响、声像、音量与预设选择。
+ * - 控件基于 Shoelace，实现统一的金属红主题；
+ * - 点击 Preview 按钮会调用后端 /mix 接口（当前返回假数据）。
+ */
+export interface MixSettings {
+  reverb: number;
+  pan: number;
+  volume: number;
+  preset: string;
+}
+
+interface MixPanelProps {
+  settings: MixSettings;
+  onSettingsChange: (value: MixSettings) => void;
+  onPreview: () => void;
+  loading: boolean;
+  disabled: boolean;
+  error: string | null;
+}
+
+const MixPanel: React.FC<MixPanelProps> = ({ settings, onSettingsChange, onPreview, loading, disabled, error }) => {
+  const handleRangeChange = (key: keyof MixSettings) => (event: CustomEvent) => {
+    // Shoelace 事件目标为输入元素，取其 value 并转换为数字。
+    const target = event.target as HTMLInputElement;
+    const value = Number(target.value);
+    onSettingsChange({ ...settings, [key]: value });
+  };
+
+  const handlePresetChange = (event: CustomEvent) => {
+    const target = event.target as HTMLSelectElement;
+    onSettingsChange({ ...settings, preset: target.value });
+  };
+
+  return (
+    <section className="metal-panel rounded-xl p-8 text-sm leading-relaxed">
+      <header className="mb-6 flex flex-col gap-2">
+        <h2 className="text-2xl font-semibold text-white">Mixing Console</h2>
+        <p className="text-sm text-gray-400">
+          Fine-tune space and balance before rendering audio. These controls will map to the upcoming waveform engine.
+        </p>
+      </header>
+      <div className="grid gap-8 md:grid-cols-2">
+        <div className="space-y-6">
+          <div>
+            <label className="mb-2 block text-xs uppercase tracking-[0.25em] text-gray-500">Reverb</label>
+            <SlRange
+              className="w-full"
+              min={0}
+              max={100}
+              value={settings.reverb}
+              onSlInput={handleRangeChange("reverb")}
+            />
+            <p className="mt-2 text-xs text-gray-400">Decay intensity mapped from 0% (dry) to 100% (arena).</p>
+          </div>
+          <div>
+            <label className="mb-2 block text-xs uppercase tracking-[0.25em] text-gray-500">Pan</label>
+            <SlRange
+              className="w-full"
+              min={-100}
+              max={100}
+              value={settings.pan}
+              onSlInput={handleRangeChange("pan")}
+            />
+            <p className="mt-2 text-xs text-gray-400">Negative values move left, positive values move right.</p>
+          </div>
+        </div>
+        <div className="space-y-6">
+          <div>
+            <label className="mb-2 block text-xs uppercase tracking-[0.25em] text-gray-500">Volume (dB)</label>
+            <SlRange
+              className="w-full"
+              min={-24}
+              max={6}
+              step={0.5}
+              value={settings.volume}
+              onSlInput={handleRangeChange("volume")}
+            />
+            <p className="mt-2 text-xs text-gray-400">Adjust gain before limiting. 0 dB keeps the original loudness.</p>
+          </div>
+          <div>
+            <label className="mb-2 block text-xs uppercase tracking-[0.25em] text-gray-500">Instrument Preset</label>
+            <SlSelect value={settings.preset} onSlChange={handlePresetChange} className="w-full">
+              <SlOption value="metal-suite">Metal Suite</SlOption>
+              <SlOption value="synth-arena">Synth Arena</SlOption>
+              <SlOption value="strings-hybrid">Strings Hybrid</SlOption>
+              <SlOption value="percussion-drive">Percussion Drive</SlOption>
+            </SlSelect>
+            <p className="mt-2 text-xs text-gray-400">
+              Presets represent different multi-track templates and will map to real instruments later.
+            </p>
+          </div>
+        </div>
+      </div>
+      {error && <p className="mt-6 text-xs text-bloodred">{error}</p>}
+      <button
+        type="button"
+        className="metal-button mt-8 w-full rounded-md px-6 py-3 text-sm"
+        onClick={onPreview}
+        disabled={disabled || loading}
+      >
+        {loading ? "Rendering Preview..." : "Mix & Render"}
+      </button>
+    </section>
+  );
+};
+
+export default MixPanel;

--- a/web/src/components/steps/MotifPanel.tsx
+++ b/web/src/components/steps/MotifPanel.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+
+/**
+ * MotifPanel 组件：负责引导用户输入 Prompt 并触发动机生成。
+ * - 左侧提供 Prompt 文本域；
+ * - 右侧展示最近一次生成摘要，强调需要锁定后才能前往下一步。
+ */
+interface MotifPanelProps {
+  prompt: string;
+  onPromptChange: (value: string) => void;
+  onGenerate: () => void;
+  loading: boolean;
+  error: string | null;
+  summary: string | null;
+  projectTitle: string | null;
+}
+
+const MotifPanel: React.FC<MotifPanelProps> = ({
+  prompt,
+  onPromptChange,
+  onGenerate,
+  loading,
+  error,
+  summary,
+  projectTitle,
+}) => {
+  return (
+    <section className="metal-panel rounded-xl p-8 text-sm leading-relaxed">
+      <header className="mb-6 flex flex-col gap-2">
+        <h2 className="text-2xl font-semibold text-white">Motif Forge</h2>
+        <p className="text-sm text-gray-400">
+          Enter a vivid description and forge a primary motif before expanding the arrangement.
+        </p>
+      </header>
+      <div className="grid gap-8 md:grid-cols-2">
+        <div className="flex flex-col gap-3">
+          <label className="text-xs uppercase tracking-[0.25em] text-gray-500">Creative Prompt</label>
+          <textarea
+            className="min-h-[220px] rounded-lg border border-gray-700 bg-black/40 p-4 text-sm text-gray-100 outline-none focus:border-bloodred focus:ring-1 focus:ring-bloodred/60"
+            value={prompt}
+            onChange={(event) => onPromptChange(event.target.value)}
+            placeholder="Describe the atmosphere, pacing, and instrumentation you want to explore."
+          />
+          {error && <p className="text-xs text-bloodred">{error}</p>}
+          <button
+            type="button"
+            className="metal-button mt-2 w-full rounded-md px-6 py-3 text-sm"
+            onClick={onGenerate}
+            disabled={loading || !prompt.trim()}
+          >
+            {loading ? "Generating..." : "Generate Motif"}
+          </button>
+        </div>
+        <div className="rounded-lg border border-bloodred/20 bg-black/30 p-4">
+          <h3 className="text-lg font-semibold text-white">Latest Result</h3>
+          {summary ? (
+            <div className="mt-3 space-y-3 text-sm text-gray-300">
+              <p className="text-xs uppercase tracking-[0.2em] text-gray-500">Project Title</p>
+              <p className="text-base text-white">{projectTitle ?? "Untitled"}</p>
+              <p className="text-xs uppercase tracking-[0.2em] text-gray-500">Motif Notes</p>
+              <p className="whitespace-pre-line text-sm text-gray-200">{summary}</p>
+            </div>
+          ) : (
+            <p className="mt-4 text-sm text-gray-500">
+              Motif metadata will appear here after generation. Lock the idea before moving forward.
+            </p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default MotifPanel;

--- a/web/src/components/steps/RenderPanel.tsx
+++ b/web/src/components/steps/RenderPanel.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+
+/**
+ * RenderPanel 组件：最终试听与下载界面，展示项目 ID 与标题。
+ * - 当混音结果可用时提供音频播放器；
+ * - 继续沿用金属色块背景营造收官仪式感。
+ */
+interface RenderPanelProps {
+  audioUrl: string | null;
+  midiUrl: string | null;
+  projectTitle: string | null;
+  projectId: string;
+}
+
+const RenderPanel: React.FC<RenderPanelProps> = ({ audioUrl, midiUrl, projectTitle, projectId }) => {
+  return (
+    <section className="metal-panel rounded-xl p-8 text-sm leading-relaxed">
+      <header className="mb-6 flex flex-col gap-2">
+        <h2 className="text-2xl font-semibold text-white">Final Track</h2>
+        <p className="text-sm text-gray-400">
+          Celebrate the completed piece. Export assets and get ready for the next iteration.
+        </p>
+      </header>
+      <div className="rounded-xl border border-bloodred/30 bg-gradient-to-br from-graysteel/40 via-black/60 to-black/80 p-6">
+        <div className="flex flex-col gap-4 text-sm text-gray-300">
+          <div>
+            <p className="text-xs uppercase tracking-[0.3em] text-gray-500">Project ID</p>
+            <p className="text-lg font-semibold text-white">{projectId}</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.3em] text-gray-500">Track Title</p>
+            <p className="text-xl font-bold text-white">{projectTitle ?? "Untitled Metal Render"}</p>
+          </div>
+          {audioUrl ? (
+            <div className="flex flex-col gap-3">
+              <p className="text-xs uppercase tracking-[0.3em] text-gray-500">Preview</p>
+              <audio controls className="w-full rounded-lg border border-bloodred/40 bg-black/50 p-2">
+                <source src={audioUrl} />
+                Your browser does not support the audio element.
+              </audio>
+              <p className="text-sm text-gray-400">🎵 Track Ready!</p>
+            </div>
+          ) : (
+            <p className="text-sm text-gray-500">
+              Render the mix to unlock the final preview. The player will appear here once audio is available.
+            </p>
+          )}
+          <div className="mt-4 flex flex-wrap gap-3">
+            <a
+              className="metal-button inline-flex items-center justify-center rounded-md px-6 py-3 text-sm"
+              href={midiUrl ?? "#"}
+              download
+              aria-disabled={!midiUrl}
+              onClick={(event) => {
+                if (!midiUrl) {
+                  event.preventDefault();
+                }
+              }}
+            >
+              Download MIDI
+            </a>
+            <a
+              className="metal-button inline-flex items-center justify-center rounded-md px-6 py-3 text-sm"
+              href={audioUrl ?? "#"}
+              download
+              aria-disabled={!audioUrl}
+              onClick={(event) => {
+                if (!audioUrl) {
+                  event.preventDefault();
+                }
+              }}
+            >
+              Download Audio
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default RenderPanel;

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./styles.css";
+import "@shoelace-style/shoelace/dist/themes/dark.css"; // 引入 Shoelace 深色主题，确保控件与金属 UI 色调统一。
 import { I18nProvider } from "./i18n"; // 引入轻量级多语言 Provider，确保所有子组件可访问 t()。
 
 /**

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,8 +1,94 @@
+@import url("https://fonts.googleapis.com/css2?family=Orbitron:wght@400;500;600;700&display=swap");
+
 @tailwind base; /* 引入 Tailwind 的基础样式，重置浏览器默认样式。 */
 @tailwind components; /* 引入预设组件类，便于快速布局。 */
 @tailwind utilities; /* 引入工具类集合，用于组合式开发。 */
 
-/* 深色主题设置：Tone.js 播放器在深色背景下更易对比。 */
+/* 深色金属主题：使用径向渐变与 Orbitron 字体构建沉浸式舞台氛围。 */
 :root {
   color-scheme: dark;
+}
+
+body {
+  @apply bg-darkmetal text-gray-200 font-orbitron;
+  background-image: radial-gradient(circle at 50% 50%, #1b1b1b 0%, #0a0a0a 100%);
+  min-height: 100vh;
+}
+
+/* 金属质感按钮：默认内凹，悬停时点亮红色描边体现交互焦点。 */
+.metal-button {
+  background: linear-gradient(145deg, #2a2a2a, #181818);
+  border: 1px solid #444;
+  box-shadow: inset 0 1px #555, 0 8px 16px rgba(0, 0, 0, 0.6);
+  color: #f5f5f5;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.metal-button:hover {
+  background: linear-gradient(145deg, #3a0a0a, #200000);
+  border-color: #e50914;
+  box-shadow: inset 0 1px #e50914, 0 12px 24px rgba(229, 9, 20, 0.35);
+  transform: translateY(-1px);
+}
+
+.metal-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.05), 0 0 0 transparent;
+}
+
+/* 面板容器使用轻微边框与发光描边强调卡片层次。 */
+.metal-panel {
+  background: linear-gradient(160deg, rgba(30, 30, 30, 0.95), rgba(12, 12, 12, 0.95));
+  border: 1px solid rgba(90, 90, 90, 0.35);
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.04), 0 24px 48px rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(12px);
+}
+
+/* 步骤切换淡入动画，提升阶段过渡的仪式感。 */
+@keyframes fadeMetal {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@layer utilities {
+  .animate-metal-fade {
+    animation: fadeMetal 0.35s ease forwards;
+  }
+}
+
+/* 红色呼吸灯用于高亮当前步骤。 */
+.glow-line {
+  position: relative;
+}
+
+.glow-line::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 -4px 0;
+  height: 2px;
+  background: linear-gradient(90deg, rgba(229, 9, 20, 0) 0%, rgba(229, 9, 20, 0.85) 50%, rgba(229, 9, 20, 0) 100%);
+  filter: blur(1px);
+}
+
+/* Shoelace 旋钮配色：统一为血红色调，确保控件风格一致。 */
+sl-range::part(base) {
+  --track-color: rgba(229, 9, 20, 0.2);
+  --track-active-color: #e50914;
+  --thumb-color: #e50914;
+}
+
+sl-select::part(tag-base),
+sl-input::part(base) {
+  background-color: rgba(20, 20, 20, 0.85);
+  border: 1px solid rgba(229, 9, 20, 0.25);
+  color: #f5f5f5;
 }

--- a/web/tailwind.config.cjs
+++ b/web/tailwind.config.cjs
@@ -1,11 +1,32 @@
 /**
  * TailwindCSS 配置：限定扫描范围并允许按需生成原子类，
- * 避免在生产环境打包冗余样式。
+ * 避免在生产环境打包冗余样式。本轮扩展金属质感主题色，
+ * 以便在组件中直接使用统一色板与字体。
  */
 module.exports = {
   content: ["./index.html", "./src/**/*.{ts,tsx}"], // 扫描模板与组件内的类名。
   theme: {
-    extend: {}, // 可按需扩展主题色/字体，此处保持默认即可。
+    extend: {
+      colors: {
+        // 金属黑红主题：深色背景与高饱和红色用于强调交互状态。
+        darkmetal: "#0b0b0b",
+        bloodred: "#e50914",
+        graysteel: "#2a2a2a",
+        gunmetal: "#1b1b1b",
+      },
+      fontFamily: {
+        // Orbitron 字体体现未来感，搭配金属 UI 风格。
+        orbitron: ["Orbitron", "sans-serif"],
+      },
+      boxShadow: {
+        // 自定义内凹阴影模拟金属面板的压铸质感。
+        metal: "inset 0 1px 0 rgba(255,255,255,0.08), 0 12px 24px rgba(0,0,0,0.5)",
+      },
+      backgroundImage: {
+        // Radial 渐变用于应用背景，制造聚光灯效果。
+        "metal-radial": "radial-gradient(circle at 50% 50%, #1b1b1b 0%, #0a0a0a 100%)",
+      },
+    },
   },
   plugins: [], // 当前无需额外插件，后续可根据设计体系引入。
 };


### PR DESCRIPTION
## Summary
- rebuild the React front end around a five-step motif → final track pipeline with metal themed layout and new panels
- extend theme assets and Shoelace integration plus add a placeholder /mix endpoint with client wiring
- document the Version 0.3 UI flow in the README for the black-red metal experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6356592a483289de41ac897279db9