### PR TITLE
Add experimental audio rendering pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,12 @@ Prompt → 解析层(parsing) → 骨架JSON(schema) → 动机生成(motif)
 - Black-Red Metal Theme
 - Step-by-Step Music Generation
   1. Motif → 2. Melody → 3. MIDI → 4. Mix → 5. Final Track
-- Mixing step currently simulated; future versions will include audio rendering (API integration planned)
+- Mixing step now uploads MIDI to an experimental audio renderer stub.
+
+## 🔊 Audio Rendering (Experimental)
+- POST /render/audio/ : Upload MIDI + style → returns audio URL
+- Default renderer: simulated (no real AI)
+- Future: integrate MusicGen or Mubert API
 
 ### 典型操作流程
 1. 在 Web UI 输入 Prompt 并点击“生成”。

--- a/src/motifmaker/api.py
+++ b/src/motifmaker/api.py
@@ -16,6 +16,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel
 
+from .audio_render import router as audio_render_router
 from .config import settings
 from .errors import (
     MMError,
@@ -46,6 +47,8 @@ app.add_middleware(
     allow_headers=["Content-Type", "Authorization"],
     allow_credentials=False,
 )
+
+app.include_router(audio_render_router)
 
 
 @app.middleware("http")

--- a/src/motifmaker/audio_render.py
+++ b/src/motifmaker/audio_render.py
@@ -1,0 +1,41 @@
+"""Audio render router integrating the mix stage with an AI-ready endpoint.
+
+This module intentionally keeps the MIDI rendering pipeline untouched while
+exposing a dedicated entry point for waveform generation. The implementation is
+currently a stub that mimics an external AI service. Future work can swap the
+stub with real providers such as MusicGen, AudioLDM or a proprietary model.
+"""
+
+from __future__ import annotations
+
+import os
+from fastapi import APIRouter, Form, UploadFile
+
+router = APIRouter(prefix="/render/audio", tags=["Audio Render"])
+
+
+@router.post("/")
+async def render_audio(
+    midi_file: UploadFile,
+    style: str = Form("cinematic"),
+    intensity: float = Form(0.5),
+    reverb: float | None = Form(None),
+    pan: float | None = Form(None),
+    volume: float | None = Form(None),
+    preset: str | None = Form(None),
+) -> dict[str, object]:
+    """Receive a MIDI file and optional mix parameters, then return an audio URL.
+
+    The handler currently simulates an AI service by returning a deterministic
+    path in the outputs directory. When wired to a real model, this endpoint can
+    stream progress, upload the generated waveform to object storage, or return
+    signed download links. The additional mix parameters are accepted for future
+    use so the API contract remains stable as capabilities grow.
+    """
+
+    original_name = midi_file.filename or "rendered.mid"
+    stem, _ = os.path.splitext(original_name)
+    safe_stem = stem or "rendered"
+
+    fake_audio_path = f"/outputs/{safe_stem}.wav"
+    return {"ok": True, "audio_url": fake_audio_path, "style": style, "intensity": intensity}


### PR DESCRIPTION
## Summary
- add a FastAPI audio rendering router that stubs an external waveform service and registers it with the main API
- wire the Mix panel to upload the current MIDI to the new endpoint, capture audio previews, and expose additional mix controls
- document the experimental audio rendering flow in the README

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e645f749c8832891b6dd67a01f0869