### PR TITLE
Implement placeholder audio rendering pipeline with frontend integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,12 @@ Prompt → 解析层(parsing) → 骨架JSON(schema) → 动机生成(motif)
   1. Motif → 2. Melody → 3. MIDI → 4. Mix → 5. Final Track
 - Mixing step now uploads MIDI to an experimental audio renderer stub.
 
-## 🔊 Audio Rendering (Experimental)
-- POST /render/audio/ : Upload MIDI + style → returns audio URL
-- Default renderer: simulated (no real AI)
-- Future: integrate MusicGen or Mubert API
+## 🔊 Audio Rendering (Placeholder, Ready for AI)
+- Endpoint: POST /render/
+- Inputs: either upload a MIDI file (midi_file) or pass an existing path (midi_path under /outputs)
+- Output: a WAV file URL under /outputs (placeholder sine-wave render for now)
+- Frontend: Mix panel can render & preview the audio
+- Production note: replace placeholder with real AI providers (e.g. MusicGen/Mubert) in `audio_render.py::render_via_provider`
 
 ### 典型操作流程
 1. 在 Web UI 输入 Prompt 并点击“生成”。

--- a/src/motifmaker/api.py
+++ b/src/motifmaker/api.py
@@ -14,10 +14,11 @@ from fastapi import Depends, FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
 from .audio_render import router as audio_render_router
-from .config import settings
+from .config import settings, OUTPUT_DIR
 from .errors import (
     MMError,
     PersistenceError,
@@ -48,6 +49,12 @@ app.add_middleware(
     allow_credentials=False,
 )
 
+# 中文注释：挂载静态目录前确保输出路径存在，避免启动时因目录缺失而失败。
+ensure_directory(OUTPUT_DIR)
+# 中文注释：开发阶段直接挂载 outputs 目录用于提供 MIDI/WAV 下载；生产环境建议使用 Nginx/Caddy 等专业静态服务。
+app.mount("/outputs", StaticFiles(directory=OUTPUT_DIR), name="outputs")
+
+# 中文注释：注册音频渲染路由，保持主应用初始化时完成依赖注入。
 app.include_router(audio_render_router)
 
 

--- a/src/motifmaker/audio_render.py
+++ b/src/motifmaker/audio_render.py
@@ -1,41 +1,193 @@
-"""Audio render router integrating the mix stage with an AI-ready endpoint.
-
-This module intentionally keeps the MIDI rendering pipeline untouched while
-exposing a dedicated entry point for waveform generation. The implementation is
-currently a stub that mimics an external AI service. Future work can swap the
-stub with real providers such as MusicGen, AudioLDM or a proprietary model.
+"""
+audio_render.py
+说明：本模块提供“音频渲染”API 的占位实现。
+- 支持上传 MIDI 或传入已存在的 midi_path
+- 当前采用纯本地合成一个短正弦波 wav 作为“渲染占位”
+- 未来可在 render_via_provider() 中接入 MusicGen/Mubert 等外部服务
 """
 
 from __future__ import annotations
 
-import os
-from fastapi import APIRouter, Form, UploadFile
+import time
+import wave
+from pathlib import Path
+from typing import Optional
 
-router = APIRouter(prefix="/render/audio", tags=["Audio Render"])
+import numpy as np
+from fastapi import APIRouter, UploadFile, File, Form
+from fastapi.responses import JSONResponse
+
+from .config import OUTPUT_DIR
+from .errors import MMError, ValidationError, RenderError
+from .logging_setup import get_logger
+from .utils import ensure_directory
+
+# 中文注释：FastAPI 路由集中在此处，prefix 统一为 /render，方便前端调用。
+router = APIRouter(prefix="/render", tags=["AudioRender"])
+logger = get_logger(__name__)
+
+# 中文注释：兼容旧的工具函数命名，避免重复实现。
+ensure_dir = ensure_directory
+
+
+def _safe_outputs_dir() -> Path:
+    """中文注释：确保输出目录存在，且禁止目录穿越。"""
+
+    out = ensure_dir(OUTPUT_DIR)
+    return out
+
+
+def _sine_wav(path: Path, seconds: float = 6.0, samplerate: int = 44100, freq: float = 440.0) -> float:
+    """
+    生成一段正弦波 wav（占位渲染），返回时长（秒）。
+    中文注释：在没有接入真实 AI 的情况下，用该方法快速得到可播放的音频文件。
+    """
+
+    t = np.linspace(0, seconds, int(samplerate * seconds), endpoint=False)
+    # 中文注释：加入淡入淡出避免音频瞬态造成爆音，幅度控制在 0.2 以内降低音量。
+    fade = np.linspace(0, 1, len(t))
+    waveform = 0.2 * np.sin(2 * np.pi * freq * t) * fade
+    waveform_int16 = (waveform * 32767).astype(np.int16)
+    with wave.open(str(path), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)  # 中文注释：16-bit 采样宽度即可满足占位需求。
+        wf.setframerate(samplerate)
+        wf.writeframes(waveform_int16.tobytes())
+    return seconds
+
+
+def _derive_audio_name(midi_name: str) -> str:
+    """中文注释：基于 midi 文件名 + 时间戳派生一个不冲突的 wav 名称。"""
+
+    stem = Path(midi_name).stem or "track"
+    ts = int(time.time())
+    return f"{stem}_{ts}.wav"
+
+
+def render_via_provider(midi_path: Path, style: str, intensity: float) -> Path:
+    """
+    中文注释：真实渲染入口（预留壳）。
+    当前返回占位生成；未来可在此调用外部 API（如 MusicGen），并保存返回的音频。
+    """
+
+    out_dir = _safe_outputs_dir()
+    out_path = out_dir / _derive_audio_name(midi_path.name)
+    # 中文注释：根据强度调整频率，模拟不同渲染参数带来的变化。
+    base_freq = 440.0
+    freq = base_freq + max(0.0, min(intensity, 1.0)) * 100.0
+    _sine_wav(out_path, seconds=6.0, freq=freq)
+    return out_path
 
 
 @router.post("/")
 async def render_audio(
-    midi_file: UploadFile,
-    style: str = Form("cinematic"),
-    intensity: float = Form(0.5),
-    reverb: float | None = Form(None),
-    pan: float | None = Form(None),
-    volume: float | None = Form(None),
-    preset: str | None = Form(None),
-) -> dict[str, object]:
-    """Receive a MIDI file and optional mix parameters, then return an audio URL.
-
-    The handler currently simulates an AI service by returning a deterministic
-    path in the outputs directory. When wired to a real model, this endpoint can
-    stream progress, upload the generated waveform to object storage, or return
-    signed download links. The additional mix parameters are accepted for future
-    use so the API contract remains stable as capabilities grow.
+    midi_file: Optional[UploadFile] = File(default=None),
+    midi_path: Optional[str] = Form(default=None),
+    style: str = Form(default="cinematic"),
+    intensity: float = Form(default=0.5),
+):
+    """
+    中文说明：
+    - 支持二选一输入：上传的 midi_file 或已有的 midi_path（outputs 内）
+    - 使用占位合成生成 wav 音频，并返回可访问的 audio_url
+    - 未来可将 render_via_provider 替换为真实 AI 渲染
     """
 
-    original_name = midi_file.filename or "rendered.mid"
-    stem, _ = os.path.splitext(original_name)
-    safe_stem = stem or "rendered"
+    try:
+        out_dir = _safe_outputs_dir()
+        chosen_midi_path: Optional[Path] = None
 
-    fake_audio_path = f"/outputs/{safe_stem}.wav"
-    return {"ok": True, "audio_url": fake_audio_path, "style": style, "intensity": intensity}
+        if midi_file is not None:
+            # 中文注释：将上传的 MIDI 存到 outputs，文件名加时间戳避免覆盖。
+            original_name = midi_file.filename or "input.mid"
+            suffix = Path(original_name).suffix or ".mid"
+            temp_name = f"upload_{int(time.time())}{suffix}"
+            tmp_midi = out_dir / temp_name
+            content = await midi_file.read()
+            if not content:
+                raise ValidationError("uploaded midi file is empty", details={"reason": "midi_file is empty"})
+            tmp_midi.write_bytes(content)
+            chosen_midi_path = tmp_midi
+
+        if midi_path and not chosen_midi_path:
+            # 中文注释：校验传入的路径，确保位于 outputs/ 下方，避免目录穿越。
+            base_dir = out_dir
+            incoming = Path(midi_path)
+            try:
+                if incoming.is_absolute():
+                    try:
+                        relative = incoming.relative_to(base_dir)
+                    except ValueError:
+                        incoming_str = str(incoming)
+                        if incoming_str.startswith("/outputs/"):
+                            trimmed = Path(incoming_str.lstrip("/"))
+                            if trimmed.parts and trimmed.parts[0] == base_dir.name:
+                                relative = Path(*trimmed.parts[1:]) if len(trimmed.parts) > 1 else Path(trimmed.name)
+                            else:
+                                relative = Path(trimmed.name)
+                        else:
+                            raise ValidationError("midi_path must be inside outputs/", details={"path": midi_path})
+                else:
+                    parts = incoming.parts
+                    if parts and parts[0] == base_dir.name:
+                        relative = Path(*parts[1:]) if len(parts) > 1 else Path(incoming.name)
+                    else:
+                        relative = incoming
+                resolved = (base_dir / relative).resolve()
+            except ValueError as exc:  # noqa: PERF203
+                raise ValidationError("midi_path must be inside outputs/", details={"path": midi_path}) from exc
+            if base_dir not in resolved.parents and resolved != base_dir:
+                raise ValidationError("midi_path must be inside outputs/", details={"path": midi_path})
+            if not resolved.exists():
+                raise ValidationError("midi_path not found", details={"path": midi_path})
+            if not resolved.is_file():
+                raise ValidationError("midi_path must be a file", details={"path": midi_path})
+            chosen_midi_path = resolved
+
+        if not chosen_midi_path:
+            raise ValidationError("either midi_file or midi_path is required")
+
+        # 中文注释：调用占位渲染函数，未来只需替换该调用即可接入真实服务。
+        try:
+            out_audio = render_via_provider(
+                chosen_midi_path,
+                style=style,
+                intensity=float(intensity),
+            )
+        except Exception as exc:  # 中文注释：捕获底层异常并转换为业务错误，便于统一响应。
+            logger.exception("render provider failure")
+            raise RenderError("placeholder render failed") from exc
+
+        audio_url = f"/outputs/{out_audio.name}"
+
+        return JSONResponse(
+            {
+                "ok": True,
+                "result": {
+                    "audio_url": audio_url,
+                    "duration_sec": 6.0,
+                    "renderer": "placeholder-sine",
+                    "style": style,
+                    "intensity": float(intensity),
+                },
+            }
+        )
+
+    except MMError as err:
+        # 中文注释：统一记录业务异常，方便观察错误码与上下文。
+        logger.error("render error: %s", err)
+        return JSONResponse(
+            {"ok": False, "error": {"code": err.code, "message": err.message, "details": err.details}},
+            status_code=err.http_status,
+        )
+    except Exception as exc:  # noqa: BLE001
+        # 中文注释：兜底异常，防止堆栈泄露给客户端，同时记录日志排查。
+        logger.exception("render internal error")
+        return JSONResponse(
+            {
+                "ok": False,
+                "error": {"code": "E_RENDER", "message": "internal rendering error"},
+            },
+            status_code=500,
+        )
+

--- a/src/motifmaker/config.py
+++ b/src/motifmaker/config.py
@@ -71,3 +71,7 @@ class Settings:
 
 settings = Settings.from_env()
 """全局唯一的配置实例，供其它模块引用。"""
+
+# 中文注释：输出目录常量供路由等模块引用，保持配置来源单一。
+OUTPUT_DIR = settings.output_dir
+

--- a/tests/test_audio_render.py
+++ b/tests/test_audio_render.py
@@ -1,0 +1,79 @@
+"""音频渲染 API 的占位实现测试用例。"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Tuple
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def render_client(tmp_path, monkeypatch) -> Tuple[TestClient, Path]:
+    """构造使用临时输出目录的 FastAPI TestClient。"""
+
+    outputs_dir = tmp_path / "outputs"
+    monkeypatch.setenv("OUTPUT_DIR", str(outputs_dir))
+
+    # 中文注释：重新加载配置与路由模块，确保使用新的输出目录。
+    config_module = importlib.import_module("motifmaker.config")
+    importlib.reload(config_module)
+    audio_render_module = importlib.import_module("motifmaker.audio_render")
+    importlib.reload(audio_render_module)
+
+    app = FastAPI()
+    app.include_router(audio_render_module.router)
+
+    return TestClient(app), Path(config_module.OUTPUT_DIR)
+
+
+def test_render_with_existing_midi_path(render_client):
+    """仅传递 midi_path 时应返回音频 URL 并生成占位 wav。"""
+
+    client, output_dir = render_client
+    output_dir.mkdir(parents=True, exist_ok=True)
+    midi_path = output_dir / "demo.mid"
+    midi_path.write_bytes(b"MThd")
+
+    response = client.post("/render/", data={"midi_path": f"/outputs/{midi_path.name}"})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    audio_url = payload["result"]["audio_url"]
+    assert audio_url.endswith(".wav")
+    audio_file = output_dir / Path(audio_url).name
+    assert audio_file.exists()
+
+
+def test_render_with_uploaded_file(render_client):
+    """上传 midi_file 时同样应生成音频并返回 URL。"""
+
+    client, output_dir = render_client
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    files = {"midi_file": ("upload.mid", b"MThd", "audio/midi")}
+    response = client.post(
+        "/render/",
+        files=files,
+        data={"style": "cinematic", "intensity": "0.7"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    audio_url = payload["result"]["audio_url"]
+    audio_file = output_dir / Path(audio_url).name
+    assert audio_file.exists()
+
+
+def test_render_validation_failure(render_client):
+    """若既未上传文件也未提供路径，则返回校验错误。"""
+
+    client, _ = render_client
+    response = client.post("/render/")
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "E_VALIDATION"

--- a/web/src/components/steps/MixPanel.tsx
+++ b/web/src/components/steps/MixPanel.tsx
@@ -1,165 +1,231 @@
-import React from "react";
-import { SlRange, SlSelect, SlOption } from "@shoelace-style/shoelace/dist/react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { SlAlert, SlRadio, SlRadioGroup } from "@shoelace-style/shoelace/dist/react";
+
+import { AudioRenderResult, renderAudio, resolveAssetUrl } from "../../api";
 
 /**
- * MixPanel 组件：模拟混音台调参，提供混响、声像、音量与预设选择。
- * - 控件基于 Shoelace，实现统一的金属红主题；
- * - 点击 Render 按钮会调用后端 /render/audio 接口获取占位音频。
+ * MixPanel 组件：在流程的混音阶段触发音频渲染，占位实现会在本地生成正弦波音频。
+ * 中文注释：
+ * - 该阶段负责将前序生成的 MIDI 转化为可试听的 WAV，未来只需替换 renderAudio 的实现即可接入外部 AI 服务；
+ * - 组件内部管理上传/路径选择、风格与强度调节，并在成功后将结果回传给父组件；
+ * - 保持 UI 文案为英文，方便后续接入国际化或设计系统。
  */
-export type MixStyle = "cinematic" | "electronic" | "lo-fi" | "pop";
 
-export interface MixSettings {
-  reverb: number;
-  pan: number;
-  volume: number;
-  intensity: number;
-  preset: string;
-  style: MixStyle;
-}
+const STYLE_OPTIONS = ["cinematic", "electronic", "lo-fi", "pop"] as const;
+export type StyleOption = (typeof STYLE_OPTIONS)[number];
+
+type SourceOption = "last" | "upload";
 
 interface MixPanelProps {
-  settings: MixSettings;
-  onSettingsChange: (value: MixSettings) => void;
-  onRender: () => void;
-  loading: boolean;
-  disabled: boolean;
-  error: string | null;
+  lastMidiPath: string | null;
+  lastMidiUrl: string | null;
   audioUrl: string | null;
+  style: StyleOption;
+  intensity: number;
+  onStyleChange: (value: StyleOption) => void;
+  onIntensityChange: (value: number) => void;
+  onAudioRendered: (payload: { resolvedUrl: string; rawUrl: string; meta: AudioRenderResult }) => void;
 }
 
-const numericKeys: Array<keyof Pick<MixSettings, "reverb" | "pan" | "volume" | "intensity">> = [
-  "reverb",
-  "pan",
-  "volume",
-  "intensity",
-];
+const MixPanel: React.FC<MixPanelProps> = ({
+  lastMidiPath,
+  lastMidiUrl,
+  audioUrl,
+  style,
+  intensity,
+  onStyleChange,
+  onIntensityChange,
+  onAudioRendered,
+}) => {
+  const canUseLast = Boolean(lastMidiPath);
+  const [source, setSource] = useState<SourceOption>(canUseLast ? "last" : "upload");
+  const [uploadFile, setUploadFile] = useState<File | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
 
-const MixPanel: React.FC<MixPanelProps> = ({ settings, onSettingsChange, onRender, loading, disabled, error, audioUrl }) => {
-  const handleRangeChange = (key: (typeof numericKeys)[number]) => (event: CustomEvent) => {
-    // Shoelace 事件目标为输入元素，取其 value 并转换为数字。
-    const target = event.target as HTMLInputElement;
-    const value = Number(target.value);
-    onSettingsChange({ ...settings, [key]: value });
-  };
+  useEffect(() => {
+    // 中文注释：当新的 MIDI 路径生成时，默认切换为“使用最近一次生成的 MIDI”。
+    if (lastMidiPath) {
+      setSource("last");
+    } else {
+      setSource("upload");
+    }
+  }, [lastMidiPath]);
 
-  const handlePresetChange = (event: CustomEvent) => {
-    const target = event.target as HTMLSelectElement;
-    onSettingsChange({ ...settings, preset: target.value });
-  };
+  const resolvedMidiUrl = useMemo(() => resolveAssetUrl(lastMidiUrl), [lastMidiUrl]);
 
-  const handleStyleChange = (event: CustomEvent) => {
-    const target = event.target as HTMLSelectElement;
-    onSettingsChange({ ...settings, style: target.value as MixStyle });
-  };
+  const handleSourceChange = useCallback((event: CustomEvent<{ value: string }>) => {
+    const value = event.detail.value as SourceOption;
+    setSource(value);
+    setError(null);
+  }, []);
+
+  const handleFileChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] ?? null;
+    setUploadFile(file);
+    setError(null);
+  }, []);
+
+  const handleStyleChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      onStyleChange(event.target.value as StyleOption);
+    },
+    [onStyleChange]
+  );
+
+  const handleIntensityChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      onIntensityChange(Number(event.target.value));
+    },
+    [onIntensityChange]
+  );
+
+  const handleRender = useCallback(async () => {
+    // 中文注释：调用 renderAudio 前重置错误提示并显示加载状态。
+    setError(null);
+    setLoading(true);
+    try {
+      let file: File | undefined;
+      let midiPath: string | undefined;
+
+      if (source === "upload") {
+        if (!uploadFile) {
+          throw new Error("Please upload a MIDI file first.");
+        }
+        file = uploadFile;
+      } else {
+        if (!lastMidiPath) {
+          throw new Error("No generated MIDI found. Upload one instead.");
+        }
+        midiPath = lastMidiPath;
+      }
+
+      const result = await renderAudio({
+        file,
+        midiPath,
+        style,
+        intensity,
+      });
+
+      const resolved = resolveAssetUrl(result.audio_url);
+      if (!resolved) {
+        throw new Error("Audio URL missing from render response.");
+      }
+
+      onAudioRendered({ resolvedUrl: resolved, rawUrl: result.audio_url, meta: result });
+    } catch (err) {
+      const message = (err as Error).message || "Audio render failed. Please try again later.";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [source, uploadFile, lastMidiPath, style, intensity, onAudioRendered]);
 
   return (
     <section className="metal-panel rounded-xl p-8 text-sm leading-relaxed">
       <header className="mb-6 flex flex-col gap-2">
-        <h2 className="text-2xl font-semibold text-white">Mixing Console</h2>
+        <h2 className="text-2xl font-semibold text-white">Mix & Render</h2>
         <p className="text-sm text-gray-400">
-          Fine-tune space and balance before rendering audio. These controls will map to the upcoming waveform engine.
+          Convert your MIDI into an audio preview. This placeholder engine emits a sine wave but keeps the workflow intact.
         </p>
       </header>
-      <div className="grid gap-8 md:grid-cols-2">
-        <div className="space-y-6">
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="space-y-5">
           <div>
-            <label className="mb-2 block text-xs uppercase tracking-[0.25em] text-gray-500">Reverb</label>
-            <SlRange
-              className="w-full"
-              min={0}
-              max={100}
-              value={settings.reverb}
-              onSlInput={handleRangeChange("reverb")}
-            />
-            <p className="mt-2 text-xs text-gray-400">Decay intensity mapped from 0% (dry) to 100% (arena).</p>
-          </div>
-          <div>
-            <label className="mb-2 block text-xs uppercase tracking-[0.25em] text-gray-500">Pan</label>
-            <SlRange
-              className="w-full"
-              min={-100}
-              max={100}
-              value={settings.pan}
-              onSlInput={handleRangeChange("pan")}
-            />
-            <p className="mt-2 text-xs text-gray-400">Negative values move left, positive values move right.</p>
+            <label className="mb-2 block text-xs uppercase tracking-[0.25em] text-gray-500">Source</label>
+            <SlRadioGroup value={source} onSlChange={handleSourceChange} className="space-y-2">
+              <SlRadio value="last" disabled={!canUseLast}>
+                Use last generated MIDI
+              </SlRadio>
+              <SlRadio value="upload">Upload MIDI</SlRadio>
+            </SlRadioGroup>
+            {source === "last" && resolvedMidiUrl && (
+              <p className="mt-2 text-xs text-gray-400">
+                Latest MIDI: <a href={resolvedMidiUrl} className="text-bloodred underline" download>
+                  Download reference
+                </a>
+              </p>
+            )}
+            {source === "upload" && (
+              <div className="mt-3">
+                <input
+                  type="file"
+                  accept=".mid,.midi"
+                  onChange={handleFileChange}
+                  className="block w-full text-xs text-gray-300 file:mr-4 file:rounded-md file:border-0 file:bg-bloodred/80 file:px-4 file:py-2 file:text-white"
+                />
+                <p className="mt-2 text-xs text-gray-500">
+                  Upload a local MIDI file to render with the placeholder engine.
+                </p>
+              </div>
+            )}
           </div>
         </div>
-        <div className="space-y-6">
+
+        <div className="space-y-5">
+          <div>
+            <label className="mb-2 block text-xs uppercase tracking-[0.25em] text-gray-500">Style</label>
+            <select
+              value={style}
+              onChange={handleStyleChange}
+              className="w-full rounded-md border border-bloodred/40 bg-black/60 px-4 py-2 text-sm text-gray-200 focus:border-bloodred focus:outline-none"
+            >
+              {STYLE_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {option.replace(/-/g, " ").replace(/\b\w/g, (char) => char.toUpperCase())}
+                </option>
+              ))}
+            </select>
+            <p className="mt-2 text-xs text-gray-500">
+              Style influences downstream model selection once external providers are integrated.
+            </p>
+          </div>
           <div>
             <label className="mb-2 block text-xs uppercase tracking-[0.25em] text-gray-500">Intensity</label>
-            <SlRange
-              className="w-full"
+            <input
+              type="range"
               min={0}
-              max={100}
-              value={settings.intensity}
-              onSlInput={handleRangeChange("intensity")}
-            />
-            <p className="mt-2 text-xs text-gray-400">
-              Controls how aggressive the renderer should interpret dynamics and drive.
-            </p>
-          </div>
-          <div>
-            <label className="mb-2 block text-xs uppercase tracking-[0.25em] text-gray-500">Volume (dB)</label>
-            <SlRange
+              max={1}
+              step={0.01}
+              value={intensity}
+              onChange={handleIntensityChange}
               className="w-full"
-              min={-24}
-              max={6}
-              step={0.5}
-              value={settings.volume}
-              onSlInput={handleRangeChange("volume")}
             />
-            <p className="mt-2 text-xs text-gray-400">Adjust gain before limiting. 0 dB keeps the original loudness.</p>
+            <p className="mt-2 text-xs text-gray-500">Controls how energetic the placeholder waveform should sound.</p>
           </div>
         </div>
       </div>
-      <div className="mt-6 grid gap-8 md:grid-cols-2">
-        <div className="space-y-6">
-          <div>
-            <label className="mb-2 block text-xs uppercase tracking-[0.25em] text-gray-500">Instrument Preset</label>
-            <SlSelect value={settings.preset} onSlChange={handlePresetChange} className="w-full">
-              <SlOption value="metal-suite">Metal Suite</SlOption>
-              <SlOption value="synth-arena">Synth Arena</SlOption>
-              <SlOption value="strings-hybrid">Strings Hybrid</SlOption>
-              <SlOption value="percussion-drive">Percussion Drive</SlOption>
-            </SlSelect>
-            <p className="mt-2 text-xs text-gray-400">
-              Presets represent different multi-track templates and will map to real instruments later.
-            </p>
-          </div>
+
+      {error && (
+        <div className="mt-6">
+          <SlAlert variant="danger" open>
+            <strong slot="title">Render failed</strong>
+            <span slot="message">{error}</span>
+          </SlAlert>
         </div>
-        <div className="space-y-6">
-          <div>
-            <label className="mb-2 block text-xs uppercase tracking-[0.25em] text-gray-500">Render Style</label>
-            <SlSelect value={settings.style} onSlChange={handleStyleChange} className="w-full">
-              <SlOption value="cinematic">Cinematic</SlOption>
-              <SlOption value="electronic">Electronic</SlOption>
-              <SlOption value="lo-fi">Lo-Fi</SlOption>
-              <SlOption value="pop">Pop</SlOption>
-            </SlSelect>
-            <p className="mt-2 text-xs text-gray-400">
-              Select the AI model flavour before rendering. Each style maps to a different set of prompts downstream.
-            </p>
-          </div>
-        </div>
-      </div>
-      {error && <p className="mt-6 text-xs text-bloodred">{error}</p>}
+      )}
+
       {audioUrl && (
-        <div className="mt-6 space-y-2">
-          <p className="text-xs uppercase tracking-[0.25em] text-gray-500">Latest Render</p>
-          <audio controls className="w-full rounded-lg border border-bloodred/40 bg-black/50 p-2">
+        <div className="mt-8 space-y-2">
+          <p className="text-xs uppercase tracking-[0.3em] text-gray-500">Latest audio preview</p>
+          <audio controls className="w-full rounded-lg border border-bloodred/40 bg-black/60 p-2">
             <source src={audioUrl} />
             Your browser does not support the audio element.
           </audio>
+          <a href={audioUrl} download className="text-xs text-bloodred underline">
+            Download preview WAV
+          </a>
         </div>
       )}
+
       <button
         type="button"
         className="metal-button mt-8 w-full rounded-md px-6 py-3 text-sm"
-        onClick={onRender}
-        disabled={disabled || loading}
+        onClick={handleRender}
+        disabled={loading || (source === "last" && !lastMidiPath) || (source === "upload" && !uploadFile)}
       >
-        {loading ? "Rendering Audio..." : "Mix & Render to Audio"}
+        {loading ? "Rendering..." : "Mix & Render to Audio"}
       </button>
     </section>
   );

--- a/web/src/components/steps/RenderPanel.tsx
+++ b/web/src/components/steps/RenderPanel.tsx
@@ -31,48 +31,57 @@ const RenderPanel: React.FC<RenderPanelProps> = ({ audioUrl, midiUrl, projectTit
             <p className="text-xs uppercase tracking-[0.3em] text-gray-500">Track Title</p>
             <p className="text-xl font-bold text-white">{projectTitle ?? "Untitled Metal Render"}</p>
           </div>
+          {/* 中文注释：若音频已渲染则提供播放器与下载链接，否则提示回到 Mixing 步骤继续生成。 */}
           {audioUrl ? (
-            <div className="flex flex-col gap-3">
-              <p className="text-xs uppercase tracking-[0.3em] text-gray-500">Preview</p>
-              <audio controls className="w-full rounded-lg border border-bloodred/40 bg-black/50 p-2">
-                <source src={audioUrl} />
-                Your browser does not support the audio element.
-              </audio>
-              <p className="text-sm text-gray-400">🎵 Track Ready!</p>
+            <div className="flex flex-col gap-4">
+              <div>
+                <p className="text-xs uppercase tracking-[0.3em] text-gray-500">Preview</p>
+                <audio controls className="mt-2 w-full rounded-lg border border-bloodred/40 bg-black/50 p-2">
+                  <source src={audioUrl} />
+                  Your browser does not support the audio element.
+                </audio>
+              </div>
+              <div className="flex flex-wrap gap-3">
+                <a
+                  className="metal-button inline-flex items-center justify-center rounded-md px-6 py-3 text-sm"
+                  href={audioUrl}
+                  download
+                >
+                  Download Audio
+                </a>
+                <a
+                  className="metal-button inline-flex items-center justify-center rounded-md px-6 py-3 text-sm"
+                  href={midiUrl ?? "#"}
+                  download
+                  aria-disabled={!midiUrl}
+                  onClick={(event) => {
+                    if (!midiUrl) {
+                      event.preventDefault();
+                    }
+                  }}
+                >
+                  Download MIDI
+                </a>
+              </div>
             </div>
           ) : (
-            <p className="text-sm text-gray-500">
-              Render the mix to unlock the final preview. The player will appear here once audio is available.
-            </p>
+            <div className="space-y-4">
+              <p className="text-sm text-gray-500">Audio not rendered yet. Go to Mixing step.</p>
+              <a
+                className="metal-button inline-flex items-center justify-center rounded-md px-6 py-3 text-sm"
+                href={midiUrl ?? "#"}
+                download
+                aria-disabled={!midiUrl}
+                onClick={(event) => {
+                  if (!midiUrl) {
+                    event.preventDefault();
+                  }
+                }}
+              >
+                Download MIDI
+              </a>
+            </div>
           )}
-          <div className="mt-4 flex flex-wrap gap-3">
-            <a
-              className="metal-button inline-flex items-center justify-center rounded-md px-6 py-3 text-sm"
-              href={midiUrl ?? "#"}
-              download
-              aria-disabled={!midiUrl}
-              onClick={(event) => {
-                if (!midiUrl) {
-                  event.preventDefault();
-                }
-              }}
-            >
-              Download MIDI
-            </a>
-            <a
-              className="metal-button inline-flex items-center justify-center rounded-md px-6 py-3 text-sm"
-              href={audioUrl ?? "#"}
-              download
-              aria-disabled={!audioUrl}
-              onClick={(event) => {
-                if (!audioUrl) {
-                  event.preventDefault();
-                }
-              }}
-            >
-              Download Audio
-            </a>
-          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add a sine-wave based placeholder renderer with a new /render endpoint and static outputs mounting
- connect the Mix panel to the rendering API, allowing MIDI upload/selection, playback, and download updates in the UI
- document the new flow and add regression tests covering the audio render API

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e64ec69ce88328b724e7c2cc74fffe